### PR TITLE
Implement renamer module

### DIFF
--- a/sorter/__init__.py
+++ b/sorter/__init__.py
@@ -2,5 +2,6 @@ from .scanner import scan_paths
 from .classifier import classify  # noqa: F401
 from .reporter import build_report  # noqa: F401
 from .review import ReviewQueue  # noqa: F401
+from .renamer import generate_name  # noqa: F401
 
-__all__ = ["scan_paths", "classify", "build_report", "ReviewQueue"]
+__all__ = ["scan_paths", "classify", "build_report", "ReviewQueue", "generate_name"]

--- a/sorter/renamer.py
+++ b/sorter/renamer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import datetime as _dt
+import pathlib
+from typing import Final
+
+from slugify import slugify
+
+_DATE_FMT: Final = "%Y-%m-%d"
+
+
+def generate_name(
+    src: pathlib.Path,
+    target_dir: pathlib.Path,
+    *,
+    include_parent: bool = True,
+    date_from_mtime: bool = True,
+) -> pathlib.Path:
+    """Return a collision-free destination path inside *target_dir*.
+
+    Naming pattern (default):
+      <parent-slug>_<YYYY-MM-DD>_<base-slug>[__<N>].<ext>
+    Rules:
+      • parent-slug comes from ``src.parent.name`` (omit if ``include_parent`` is
+        False or parent is root).
+      • Date is file mtime if ``date_from_mtime``, else today.
+      • base-slug from stem (no extension).
+      • If filename already exists in ``target_dir`` (case-insensitive), append
+        ``__2``, ``__3``, … until unused.
+    Returns absolute ``Path``.
+    """
+
+    target_dir = target_dir.expanduser().resolve()
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    parent_part = (
+        slugify(src.parent.name)
+        if include_parent and src.parent.name and src.parent != pathlib.Path(src.anchor)
+        else ""
+    )
+
+    date_part = (
+        _dt.date.fromtimestamp(src.stat().st_mtime).strftime(_DATE_FMT)
+        if date_from_mtime
+        else _dt.date.today().strftime(_DATE_FMT)
+    )
+
+    base_part = slugify(src.stem) or "file"
+    ext = src.suffix.lower()
+
+    pieces = [p for p in (parent_part, date_part, base_part) if p]
+    stem = "_".join(pieces)
+
+    candidate = target_dir / f"{stem}{ext}"
+    counter = 2
+    existing = {p.name.lower() for p in target_dir.iterdir()}
+    while candidate.name.lower() in existing:
+        candidate = target_dir / f"{stem}__{counter}{ext}"
+        counter += 1
+    return candidate.resolve()

--- a/tests/test_renamer.py
+++ b/tests/test_renamer.py
@@ -1,0 +1,40 @@
+import os
+import pathlib
+
+from sorter import generate_name
+
+
+def _touch(tmp: pathlib.Path, name: str, mtime: int | None = None) -> pathlib.Path:
+    p = tmp / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("x")
+    if mtime is not None:
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+def test_basic_pattern(tmp_path):
+    src = _touch(tmp_path / "in", "Example File.TXT", mtime=946684800)
+    dest_dir = tmp_path / "out"
+    new_path = generate_name(src, dest_dir)
+    assert new_path.parent == dest_dir.resolve()
+    assert new_path.name.startswith("in_2000-01-01_example-file")
+
+
+def test_collision_resolution(tmp_path):
+    dest = tmp_path / "out"
+    a = _touch(tmp_path / "x", "a.txt")
+    n1 = generate_name(a, dest, include_parent=False, date_from_mtime=False)
+    dest.mkdir(exist_ok=True)
+    (dest / n1.name).write_text("exists")
+    n2 = generate_name(a, dest, include_parent=False, date_from_mtime=False)
+    assert n2.name.endswith("__2.txt")
+
+
+def test_case_insensitive_collision(tmp_path):
+    dest = tmp_path / "out"
+    src = _touch(tmp_path, "UPPER.TXT")
+    (dest).mkdir()
+    (dest / "upper.txt").write_text("lowercase duplicate")
+    result = generate_name(src, dest)
+    assert result.name != "upper.txt" and result.name.lower() != "upper.txt"


### PR DESCRIPTION
## Summary
- add deterministic rename helper for sorter
- expose `generate_name` in package API
- test collision-free slug generation

## Testing
- `poetry run ruff check --fix sorter tests`
- `poetry run black sorter tests`
- `poetry run mypy sorter --strict`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843637169a88322a56159163cae6cc2