### PR TITLE
Step 8: setup maintenance automation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    project: {default: {target: 0.85}}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule: { interval: "weekly" }
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "pytest"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,13 @@
+name: Coverage
+on: [push, pull_request]
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: "3.12"}
+      - run: pip install poetry
+      - run: poetry install
+      - run: poetry run pytest --cov=sorter --cov-report=xml
+      - uses: codecov/codecov-action@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,13 @@
+name: Release-please
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with: {release-type: python}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # file-flow
+
+![CI](https://github.com/<ORG>/file-sorter/actions/workflows/ci.yml/badge.svg)
+![Coverage](https://codecov.io/gh/<ORG>/file-sorter/branch/main/graph/badge.svg)
+![Release](https://img.shields.io/github/v/release/<ORG>/file-sorter)
+
+A lightweight utility for sorting files.
+
+## Maintenance
+
+This project uses **Dependabot** for weekly dependency checks and **release-please** to automate versioning and changelog generation. Code coverage results are uploaded to Codecov.

--- a/sorter/telemetry.py
+++ b/sorter/telemetry.py
@@ -1,0 +1,11 @@
+"""Sentry init stub; safe-import when DSN absent."""
+
+import os
+from contextlib import suppress
+
+_DSN = os.getenv("FILE_SORTER_SENTRY_DSN")
+if _DSN:
+    with suppress(ImportError):
+        import sentry_sdk
+
+        sentry_sdk.init(_DSN, traces_sample_rate=0.0)


### PR DESCRIPTION
## Summary
- add Dependabot for weekly pip updates
- automate releases using release-please
- track coverage on Codecov with workflow and config
- include telemetry stub for optional Sentry integration
- document badges and maintenance policy in README

## Testing
- `ruff --fix README.md sorter || true`
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_68436daa4d188322ad5236d8473ed790