### PR TITLE
Add beta feedback templates and benchmark harness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,22 @@
+name: Bug Report
+description: Report a reproducible issue
+labels: [bug]
+body:
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: How did you trigger the bug?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Logs
+      description: Paste any relevant logs or screenshots
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+issue_templates:
+  - name: bug_report.yml
+    labels: [bug]
+  - name: feature_request.yml
+    labels: [enhancement]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,16 @@
+name: Feature Request
+description: Suggest an idea or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    attributes:
+      label: Proposal
+      description: What should be added or changed?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Optional context, links or images
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## Checklist
+- [ ] Tests pass
+- [ ] Docs updated
+- [ ] Conventional commit
+- [ ] Screenshot/GIF attached if relevant

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,18 @@
+- name: bug
+  color: "d73a4a"
+- name: enhancement
+  color: "a2eeef"
+- name: perf
+  color: "cfd3d7"
+- name: good first issue
+  color: "7057ff"
+- name: docs
+  color: "0075ca"
+- name: refactor
+  color: "c2e0c6"
+- name: wontfix
+  color: "ffffff"
+- name: duplicate
+  color: "cfd3d7"
+- name: invalid
+  color: "e4e669"

--- a/.github/project_seed.json
+++ b/.github/project_seed.json
@@ -1,0 +1,14 @@
+{
+  "name": "v1.1 Board",
+  "description": "Planning for v1.1",
+  "columns": [
+    {"name": "Backlog"},
+    {"name": "In Progress"},
+    {"name": "Done"}
+  ],
+  "cards": [
+    {"note": "Duplicate Finder plugin", "column": "Backlog", "milestone": "v1.1"},
+    {"note": "GUI shell", "column": "Backlog", "milestone": "v1.1"},
+    {"note": "Nightly cron dry-run", "column": "Backlog", "milestone": "v1.1"}
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ A lightweight utility for sorting files.
 ## Maintenance
 
 This project uses **Dependabot** for weekly dependency checks and **release-please** to automate versioning and changelog generation. Code coverage results are uploaded to Codecov.
+
+## Contributing & Roadmap
+
+- Use the issue and PR templates in `.github` to report bugs and propose features.
+- Run `scripts/run_benchmarks.sh` for performance baselines.
+
+### v1.1 Targets
+- Duplicate Finder plugin
+- GUI shell
+- Nightly cron dry-run scheduler

--- a/benchmarks/benchmark_sorter.py
+++ b/benchmarks/benchmark_sorter.py
@@ -1,0 +1,21 @@
+import pathlib
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from sorter import scan_paths
+
+
+def setup_tree(tmp_path, n=10_000):
+    base = tmp_path / "data"
+    for i in range(n):
+        p = base / f"file_{i}.txt"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"x")
+    return base
+
+
+def test_scan_speed(benchmark, tmp_path):
+    root = setup_tree(tmp_path)
+    benchmark(lambda: scan_paths([root]))

--- a/poetry.lock
+++ b/poetry.lock
@@ -616,6 +616,18 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+description = "Get CPU info with pure Python"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690"},
+    {file = "py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5"},
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -653,6 +665,27 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.1.0"
+description = "A ``pytest`` fixture for benchmarking code. It will group the tests into rounds that are calibrated to the chosen timer."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest-benchmark-5.1.0.tar.gz", hash = "sha256:9ea661cdc292e8231f7cd4c10b0319e56a2118e2c09d9f50e1b3d150d2aca105"},
+    {file = "pytest_benchmark-5.1.0-py3-none-any.whl", hash = "sha256:922de2dfa3033c227c96da942d1878191afa135a29485fb942e85dff1c592c89"},
+]
+
+[package.dependencies]
+py-cpuinfo = "*"
+pytest = ">=8.1"
+
+[package.extras]
+aspect = ["aspectlib"]
+elasticsearch = ["elasticsearch"]
+histogram = ["pygal", "pygaljs", "setuptools"]
 
 [[package]]
 name = "pytest-cov"
@@ -948,4 +981,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "da7e9402e9072ce7ebe18002b654c81bfe69e2a36e1d2e9d055ecda2251f6167"
+content-hash = "2b0b2c92154921fa19c0b487f866d1aa8180e304a0cc24461b6c8dd46d2b5e40"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,11 @@ black = "^25.1.0"
 mypy = "^1.16.0"
 pytest = "^8.2.0"
 pytest-cov = "^5.0.0"
+pytest-benchmark = "^5.1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+python_files = ["test_*.py", "benchmark_*.py"]

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+poetry run pytest benchmarks --benchmark-save=baseline


### PR DESCRIPTION
## Summary
- add GitHub issue and PR templates
- provide label schema and project board seed
- introduce pytest-benchmark test and helper script
- document contributing and v1.1 roadmap in README
- enable benchmark file discovery via pytest config

## Testing
- `poetry run black README.md benchmarks scripts` *(fails: Cannot parse README.md)*
- `poetry run black benchmarks scripts`
- `./scripts/run_benchmarks.sh`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843cc2d3b8083229cf991aba2be01e5