### PR TITLE
Implement v1.0.0 release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+on:
+  push:
+    tags: ["v*.*.*"]
+jobs:
+  build:
+    strategy:
+      matrix: {os: [ubuntu-latest, macos-latest, windows-latest]}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: {python-version: "3.12"}
+      - name: Install build deps
+        run: >
+          pip install cibuildwheel==2.19 build twine pyinstaller
+      - name: Build wheels
+        run: cibuildwheel --output-dir wheelhouse
+      - name: Build sdist
+        run: python -m build --sdist -o dist
+      - name: Build single-file binary
+        run: bash scripts/build_binary.sh
+      - uses: actions/upload-artifact@v4
+        with: {name: dist, path: wheelhouse/*, if-no-files-found: error}
+      - uses: actions/upload-artifact@v4
+        with: {name: binary, path: dist/file-sorter*, if-no-files-found: error}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+      - uses: pypa/gh-action-pypi-publish@v1.8.10
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*
+            binary/*
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0 – YYYY-MM-DD
+* First stable release.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # File-Sorter
 
-![CI](https://github.com/<ORG>/file-sorter/actions/workflows/ci.yml/badge.svg) ![Coverage](https://codecov.io/gh/<ORG>/file-sorter/branch/main/graph/badge.svg) ![PyPI](https://img.shields.io/pypi/v/file-flow) ![Docs](https://img.shields.io/badge/docs-online-blue)
+![CI](https://github.com/<ORG>/file-sorter/actions/workflows/ci.yml/badge.svg) ![Coverage](https://codecov.io/gh/<ORG>/file-sorter/branch/main/graph/badge.svg) ![PyPI](https://img.shields.io/pypi/v/file-sorter) ![Docs](https://img.shields.io/badge/docs-online-blue)
 
 File-Sorter automatically organizes messy download folders. Point it at a directory and it will classify, rename and move files in seconds.
 
@@ -10,7 +10,7 @@ File-Sorter automatically organizes messy download folders. Point it at a direct
 
 ## Installation
 ```bash
-pip install file-flow
+pip install file-sorter
 ```
 
 ## Basic Usage

--- a/formula/file-sorter.rb
+++ b/formula/file-sorter.rb
@@ -1,0 +1,15 @@
+class FileSorter < Formula
+  desc     "Smart CLI to organize and clean files"
+  homepage "https://github.com/<ORG>/file-sorter"
+  url      "https://files.pythonhosted.org/packages/<PATH>/file-sorter-1.0.0.tar.gz"
+  sha256   "<FILL-IN-SHA>"
+  license  "MIT"
+  depends_on "python@3.12"
+  def install
+    system "pip3", "install", "--prefix=#{prefix}", "file-sorter==1.0.0"
+  end
+  test do
+    system "#{bin}/file-sorter", "--help"
+  end
+end
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "file-flow"
-version = "0.1.0"
+version = "1.0.0"
 description = "A lightweight utility for sorting files."
 authors = ["Your Name <you@example.com>"]
 packages = [

--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+pyinstaller sorter/cli.py --onefile -n "file-sorter" --log-level WARN
+mkdir -p dist
+mv dist/file-sorter* dist/
+


### PR DESCRIPTION
## Summary
- add release workflow for wheels, sdist and binary publishing
- create PyInstaller helper script
- bump package version to `1.0.0`
- provide Homebrew formula template
- add installation instructions and PyPI badge
- start changelog for `1.0.0`

## Testing
- `black scripts formula README.md` *(fails: cannot format README.md)*

------
https://chatgpt.com/codex/tasks/task_e_6843ce3121b08322b601d16507216246