### PR TITLE
Add duplicate finder module with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ After installing, launch with:
 ```bash
 file-sorter-gui
 ```
+
+## Find Duplicates
+```bash
+file-sorter dupes ~/Downloads
+```

--- a/sorter/__init__.py
+++ b/sorter/__init__.py
@@ -1,4 +1,5 @@
 from .scanner import scan_paths
+from .dupes import find_duplicates  # noqa: F401
 from .classifier import classify  # noqa: F401
 from .reporter import build_report  # noqa: F401
 from .review import ReviewQueue  # noqa: F401
@@ -13,5 +14,6 @@ __all__ = [
     "ReviewQueue",
     "generate_name",
     "move_with_log",
+    "find_duplicates",
     "rollback",
 ]

--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pathlib
+
+import typer  # type: ignore[import-not-found]
+from rich import print
+
+from . import scan_paths
+from .dupes import find_duplicates, delete_older as _delete_older
+
+app = typer.Typer()
+
+
+@app.command()  # type: ignore[misc]
+def dupes(
+    dirs: list[pathlib.Path] = typer.Argument(..., exists=True, readable=True),
+    delete_older: bool = typer.Option(False, help="auto-delete older copies"),
+    hardlink: bool = typer.Option(False, help="replace duplicates with hardlink"),
+) -> None:
+    files = scan_paths(dirs)
+    groups = find_duplicates(files)
+    if not groups:
+        print("[green]No duplicates detected.")
+        raise typer.Exit()
+    for digest, paths in groups.items():
+        print(f"[bold yellow]{len(paths)}×[/bold yellow] {digest[:10]} →")
+        for p in paths:
+            print(f"  • {p}")
+    if delete_older and typer.confirm("Delete older copies?"):
+        for paths in groups.values():
+            for removed in _delete_older(paths):
+                print(f"[red]- deleted[/red] {removed}")
+    if hardlink and not delete_older:
+        print("⚠️  hardlink requires delete_older to leave single copy.")
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/sorter/dupes.py
+++ b/sorter/dupes.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import pathlib
+from collections import defaultdict
+from typing import Iterable, Sequence, Dict, List
+
+_BUF = 1 << 20  # 1 MiB
+
+
+def _quick_hash(path: pathlib.Path, /, sample: int = 64 * 1024) -> str:
+    """Return SHA-256 of first + last *sample* bytes."""
+    size = path.stat().st_size
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        h.update(fp.read(sample))
+        if size > sample:
+            fp.seek(-sample, os.SEEK_END)
+            h.update(fp.read(sample))
+    return h.hexdigest()
+
+
+def _full_hash(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        while chunk := fp.read(_BUF):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def find_duplicates(
+    files: Iterable[pathlib.Path],
+    *,
+    validate_full: bool = True,
+) -> Dict[str, List[pathlib.Path]]:
+    """Group *files* by identical content."""
+    quick: Dict[str, List[pathlib.Path]] = defaultdict(list)
+    for f in files:
+        quick[_quick_hash(f)].append(f)
+    dupes: Dict[str, List[pathlib.Path]] = {}
+    for group in quick.values():
+        if len(group) < 2:
+            continue
+        if validate_full:
+            full_map: Dict[str, List[pathlib.Path]] = defaultdict(list)
+            for p in group:
+                full_map[_full_hash(p)].append(p)
+            dupes.update({k: v for k, v in full_map.items() if len(v) > 1})
+        else:
+            dupes[_quick_hash(group[0])] = group
+    return dupes
+
+
+def delete_older(dupe_group: Sequence[pathlib.Path]) -> list[pathlib.Path]:
+    """Keep newest mtime, delete others; return deleted paths."""
+    newest = max(dupe_group, key=lambda p: p.stat().st_mtime)
+    deleted: list[pathlib.Path] = []
+    for p in dupe_group:
+        if p is newest:
+            continue
+        p.unlink()
+        deleted.append(p)
+    return deleted
+
+
+__all__ = [
+    "find_duplicates",
+    "delete_older",
+]

--- a/sorter/reporter.py
+++ b/sorter/reporter.py
@@ -7,8 +7,8 @@ import subprocess
 import sys
 from typing import Iterable, Final, cast
 
-import pandas as _pd
-from openpyxl.utils import get_column_letter as _col
+import pandas as _pd  # type: ignore[import-untyped]
+from openpyxl.utils import get_column_letter as _col  # type: ignore[import-untyped]
 
 _DATE_FMT: Final = "%Y%m%d_%H%M%S"
 

--- a/tests/test_dupes.py
+++ b/tests/test_dupes.py
@@ -1,0 +1,34 @@
+import pathlib
+
+from sorter.dupes import find_duplicates, delete_older
+
+
+def _make(tmp: pathlib.Path, name: str, data: bytes) -> pathlib.Path:
+    p = tmp / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+    return p
+
+
+def test_duplicate_detection(tmp_path):
+    a = _make(tmp_path, "a.txt", b"same")
+    b = _make(tmp_path, "b/b.txt", b"same")
+    c = _make(tmp_path, "c.txt", b"diff")
+
+    groups = find_duplicates([a, b, c])
+    assert len(groups) == 1
+    only = next(iter(groups.values()))
+    assert set(only) == {a, b}
+
+
+def test_delete_older(tmp_path):
+    a = _make(tmp_path, "old.txt", b"x")
+    b = _make(tmp_path, "new.txt", b"x")
+    # make 'a' older
+    a.touch()
+    import os
+
+    os.utime(a, (1_000_000_000, 1_000_000_000))
+
+    deleted = delete_older([a, b])
+    assert deleted == [a] and not a.exists() and b.exists()


### PR DESCRIPTION
## Summary
- implement `sorter.dupes` for SHA-256 duplicate detection
- expose `find_duplicates` via package init
- add `dupes` command in new Typer CLI
- document duplicate finder usage
- test detection and deletion logic

## Testing
- `poetry run ruff --fix sorter tests` *(fails: unexpected argument)*
- `poetry run ruff check --fix sorter tests`
- `poetry run black sorter tests`
- `poetry run mypy sorter --strict`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d57272a88322a1d3216eb659a26d