### PR TITLE
Add scheduler module with nightly job setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ file-sorter-gui
 ```bash
 file-sorter dupes ~/Downloads
 ```
+
+## Scheduling
+```bash
+file-sorter schedule "0 3 * * *" ~/Downloads --dest ~/Sorted
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -188,6 +188,22 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "croniter"
+version = "6.0.0"
+description = "croniter provides iteration for datetime object with cron like format"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.6"
+groups = ["main"]
+files = [
+    {file = "croniter-6.0.0-py2.py3-none-any.whl", hash = "sha256:2f878c3856f17896979b2a4379ba1f09c83e374931ea15cc835c5dd2eee9b368"},
+    {file = "croniter-6.0.0.tar.gz", hash = "sha256:37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+pytz = ">2021.1"
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 description = "An implementation of lxml.xmlfile for the standard library"
@@ -1051,4 +1067,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "6e26d09f70610d9f01c6f5ad17b8975e494dca8b23fbfc6889c7e9ff882043fe"
+content-hash = "4be51c8e55b749e9f0e3a47c0d82f2bf517955f4c5b9096f1464a6293018e1ec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ openpyxl = "*"
 rich = "*"
 sentry-sdk = "*"
 pyqt6 = "*"
+croniter = "^6.0.0"
+python-dateutil = "^2.9.0.post0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.11.13"

--- a/scripts/install_task.ps1
+++ b/scripts/install_task.ps1
@@ -1,0 +1,2 @@
+$xmlPath = Join-Path $env:TEMP "Task.xml"
+SCHTASKS /Create /TN "FileSorterNightly" /XML $xmlPath /F

--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -34,6 +34,20 @@ def dupes(
         print("⚠️  hardlink requires delete_older to leave single copy.")
 
 
+@app.command()  # type: ignore[misc]
+def schedule(
+    cron: str = typer.Option("0 3 * * *", help="cron expression"),
+    dirs: list[pathlib.Path] = typer.Argument(...),
+    dest: pathlib.Path = typer.Option(..., "--dest"),
+) -> None:
+    """Install nightly dry-run that emails report."""
+    from .scheduler import validate_cron, install_job
+
+    validate_cron(cron)
+    install_job(cron, dirs=[*dirs], dest=dest)
+    print("[green]Scheduler entry installed.[/green]")
+
+
 def main() -> None:
     app()
 

--- a/sorter/scheduler.py
+++ b/sorter/scheduler.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import platform
+import subprocess
+import textwrap
+from typing import Final
+
+from croniter import croniter  # type: ignore[import-untyped]
+
+
+def validate_cron(expr: str) -> None:
+    """Raise `ValueError` if *expr* is not a valid 5-field cron."""
+    if not croniter.is_valid(expr):
+        raise ValueError(f"invalid cron expression: {expr}")
+
+
+def install_job(
+    cron_expr: str,
+    *,
+    dirs: list[pathlib.Path],
+    dest: pathlib.Path,
+) -> None:
+    """Register OS-level schedule that runs nightly dry-run."""
+    cmd = f"file-sorter move {' '.join(map(str, dirs))} --dest {dest} --dry-run"
+    if platform.system() == "Windows":
+        _install_windows(cron_expr, cmd)
+    else:
+        _install_cron(cron_expr, cmd)
+
+
+_DEF_HEADER: Final = "# file-sorter"
+
+
+def _install_cron(cron_expr: str, cmd: str) -> None:
+    current = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+    lines = [
+        line for line in current.stdout.splitlines() if not line.startswith(_DEF_HEADER)
+    ]
+
+    shell_cmd = f"{cmd} && file-sorter report --auto-open"
+    entry = f"{cron_expr} {shell_cmd}"
+
+    lines.append(_DEF_HEADER)
+    lines.append(entry)
+    new_cron = "\n".join(lines) + "\n"
+    subprocess.run(["crontab", "-"], input=new_cron, text=True, check=False)
+
+
+def _install_windows(cron_expr: str, cmd: str) -> None:
+    """Create or update Windows Task Scheduler entry."""
+    from datetime import datetime
+
+    itr = croniter(cron_expr, datetime.now())
+    next_time = itr.get_next(datetime)
+    hour = next_time.hour
+    minute = next_time.minute
+
+    task_xml = textwrap.dedent(
+        f"""
+        <Task version='1.2' xmlns='http://schemas.microsoft.com/windows/2004/02/mit/task'>
+          <Triggers>
+            <CalendarTrigger>
+              <StartBoundary>2024-01-01T{hour:02d}:{minute:02d}:00</StartBoundary>
+              <ScheduleByDay>
+                <DaysInterval>1</DaysInterval>
+              </ScheduleByDay>
+            </CalendarTrigger>
+          </Triggers>
+          <Actions Context='Author'>
+            <Exec>
+              <Command>{cmd}</Command>
+            </Exec>
+          </Actions>
+        </Task>
+        """
+    ).strip()
+
+    temp = pathlib.Path(os.getenv("TEMP", ".")) / "Task.xml"
+    temp.write_text(task_xml, encoding="utf-8")
+    subprocess.run(
+        [
+            "schtasks",
+            "/Create",
+            "/TN",
+            "FileSorterNightly",
+            "/XML",
+            str(temp),
+            "/F",
+        ],
+        check=False,
+    )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,14 @@
+import pytest
+
+from sorter.scheduler import validate_cron
+
+
+@pytest.mark.parametrize("expr", ["0 0 * * *", "15 4 * * 1-5"])
+def test_valid_cron(expr):
+    validate_cron(expr)  # should not raise
+
+
+@pytest.mark.parametrize("expr", ["bad", "61 0 * * *", "* * *"])
+def test_invalid_cron(expr):
+    with pytest.raises(ValueError):
+        validate_cron(expr)


### PR DESCRIPTION
## Summary
- add croniter & python-dateutil dependencies
- implement `scheduler` utilities for cron/Task Scheduler
- expose new `schedule` CLI command
- document scheduling example in README
- create tests for cron validation

## Testing
- `poetry run ruff check --fix sorter tests`
- `poetry run black sorter tests`
- `poetry run mypy sorter --strict`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843d87035c48322889ee44539d80d6b