### PR TITLE
Expand unit tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -65,7 +65,7 @@ version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version < \"3.11\""
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
@@ -81,7 +81,7 @@ version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version >= \"3.11\""
 files = [
     {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
@@ -97,12 +97,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "contourpy"
@@ -1682,6 +1682,18 @@ tornado = ["tornado (>=6)"]
 unleash = ["UnleashClient (>=6.0.1)"]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1749,6 +1761,24 @@ files = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.16.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855"},
+    {file = "typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+rich = ">=10.11.0"
+shellingham = ">=1.3.0"
+typing-extensions = ">=3.7.4.3"
+
+[[package]]
 name = "typing-extensions"
 version = "4.14.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -1759,7 +1789,6 @@ files = [
     {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
     {file = "typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4"},
 ]
-markers = {main = "python_version < \"3.11\""}
 
 [[package]]
 name = "tzdata"
@@ -1815,4 +1844,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "da9a7b0575b6f93bed440d053b8960f3f9cdeda07002fda389ac91d07f4d6cfa"
+content-hash = "eeb1534072396cad649cb839c4dacd9497b5a2cb6c85a10bcae92594b2f76e5e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ sentry-sdk = "*"
 pyqt6 = "*"
 croniter = "^6.0.0"
 python-dateutil = "^2.9.0.post0"
+typer = "^0.16.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.11.13"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,64 @@
+from typer.testing import CliRunner
+
+from sorter.cli import app
+
+
+def test_dupes_command(tmp_path, monkeypatch):
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    a.write_text("x")
+    b.write_text("x")
+
+    def fake_scan(dirs):
+        return [a, b]
+
+    monkeypatch.setattr("sorter.cli.scan_paths", fake_scan)
+    monkeypatch.setattr(
+        "sorter.cli.find_duplicates", lambda files: {"deadbeef": [a, b]}
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["dupes", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "deadbeef"[:8] in result.stdout
+
+
+def test_schedule_command(tmp_path, monkeypatch):
+    calls = {}
+
+    def fake_validate(expr):
+        calls["validate"] = expr
+
+    def fake_install(cron, *, dirs, dest):
+        calls["install"] = (cron, dirs, dest)
+
+    monkeypatch.setattr("sorter.scheduler.validate_cron", fake_validate)
+    monkeypatch.setattr("sorter.scheduler.install_job", fake_install)
+
+    runner = CliRunner()
+    dest = tmp_path / "dest"
+    result = runner.invoke(
+        app,
+        ["schedule", str(tmp_path), "--dest", str(dest), "--cron", "5 4 * * *"],
+    )
+    assert result.exit_code == 0
+    assert calls["validate"] == "5 4 * * *"
+    assert calls["install"] == ("5 4 * * *", [tmp_path], dest)
+
+
+def test_stats_command(tmp_path, monkeypatch):
+    log = tmp_path / "file-sort-log_1.jsonl"
+    log.write_text("{}\n")
+    dest = tmp_path / "out.html"
+    calls = {}
+
+    def fake_dash(logs, dest):
+        calls["dash"] = (logs, dest)
+        return dest
+
+    monkeypatch.setattr("sorter.stats.build_dashboard", fake_dash)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats", str(tmp_path), "--out", str(dest)])
+    assert result.exit_code == 0
+    assert calls["dash"] == ([log], dest)

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,0 +1,26 @@
+import json
+
+import pytest
+
+import importlib
+
+rollback_mod = importlib.import_module("sorter.rollback")
+
+
+def test_checksum_mismatch(tmp_path, monkeypatch):
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    dst.write_text("x")
+    log = tmp_path / "log.jsonl"
+    rec = {
+        "src": str(src),
+        "dst": str(dst),
+        "sha256": "expected",
+        "size": 1,
+        "epoch": 0,
+    }
+    log.write_text(json.dumps(rec) + "\n")
+
+    monkeypatch.setattr(rollback_mod, "_sha256", lambda p: "actual")
+    with pytest.raises(ValueError):
+        rollback_mod.rollback(log, strict=True)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -12,3 +12,41 @@ def test_valid_cron(expr):
 def test_invalid_cron(expr):
     with pytest.raises(ValueError):
         validate_cron(expr)
+
+from sorter import scheduler
+
+
+def test_install_job_linux(monkeypatch, tmp_path):
+    called = {}
+    monkeypatch.setattr(scheduler.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(scheduler, "_install_cron", lambda c, cmd: called.setdefault("cron", (c, cmd)))
+    monkeypatch.setattr(scheduler, "_install_windows", lambda c, cmd: (_ for _ in ()).throw(AssertionError()))
+
+    scheduler.install_job("0 1 * * *", dirs=[tmp_path], dest=tmp_path / "d")
+    assert called["cron"][0] == "0 1 * * *"
+
+
+def test_install_job_windows(monkeypatch, tmp_path):
+    called = {}
+    monkeypatch.setattr(scheduler.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(scheduler, "_install_windows", lambda c, cmd: called.setdefault("win", (c, cmd)))
+    monkeypatch.setattr(scheduler, "_install_cron", lambda c, cmd: (_ for _ in ()).throw(AssertionError()))
+
+    scheduler.install_job("0 2 * * *", dirs=[tmp_path], dest=tmp_path / "d")
+    assert called["win"][0] == "0 2 * * *"
+
+
+def test_install_cron(monkeypatch):
+    recorded = {}
+
+    def fake_run(args, *, capture_output=False, text=False, input=None, check=False):
+        if args == ["crontab", "-l"]:
+            return type("R", (), {"stdout": ""})()
+        recorded["args"] = args
+        recorded["input"] = input
+        return type("R", (), {})()
+
+    monkeypatch.setattr(scheduler.subprocess, "run", fake_run)
+    scheduler._install_cron("0 3 * * *", "cmd")
+    assert recorded["args"] == ["crontab", "-"]
+    assert "cmd && file-sorter report --auto-open" in recorded["input"]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+
+import pytest
+
+
+def test_import_without_dsn(monkeypatch):
+    monkeypatch.delenv("FILE_SORTER_SENTRY_DSN", raising=False)
+    if "sentry_sdk" in sys.modules:
+        del sys.modules["sentry_sdk"]
+    import sorter.telemetry as tel
+    importlib.reload(tel)
+
+
+def test_import_with_dsn(monkeypatch):
+    events = []
+
+    class FakeSdk:
+        def init(self, dsn, traces_sample_rate=1.0):
+            events.append((dsn, traces_sample_rate))
+
+    monkeypatch.setenv("FILE_SORTER_SENTRY_DSN", "abc")
+    monkeypatch.setitem(sys.modules, "sentry_sdk", FakeSdk())
+    import sorter.telemetry as tel
+    importlib.reload(tel)
+    assert events == [("abc", 0.0)]


### PR DESCRIPTION
## Summary
- add CLI tests covering dupes, schedule, and stats commands
- test rollback checksum mismatch
- validate scheduler installation logic
- confirm telemetry import behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843e97baba08322a79fb924e2c782ef