### PR TITLE
Add Typer CLI app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,4 @@ python_files = ["test_*.py", "benchmark_*.py"]
 
 [tool.poetry.scripts]
 file-sorter-gui = "sorter_gui.app:main"
+file-sorter = "sorter.cli:app"

--- a/sorter/__init__.py
+++ b/sorter/__init__.py
@@ -7,6 +7,7 @@ from .renamer import generate_name  # noqa: F401
 from .mover import move_with_log  # noqa: F401
 from .rollback import rollback  # noqa: F401
 from .stats import build_dashboard  # noqa: F401
+from .cli import app  # noqa: F401
 
 __all__ = [
     "scan_paths",
@@ -18,4 +19,5 @@ __all__ = [
     "find_duplicates",
     "rollback",
     "build_dashboard",
+    "app",
 ]

--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -2,26 +2,157 @@ from __future__ import annotations
 
 import pathlib
 
-import typer  # type: ignore[import-not-found]
+import typer
 from rich import print
 
-from . import scan_paths
+from .scanner import scan_paths
+from .classifier import classify
+from .reporter import build_report
+from .review import ReviewQueue
+from .renamer import generate_name
+from .mover import move_with_log
+from .rollback import rollback
 from .dupes import find_duplicates, delete_older as _delete_older
 
-app = typer.Typer()
+
+app = typer.Typer(add_completion=False, rich_markup_mode="rich")
 
 
-@app.command()  # type: ignore[misc]
+@app.callback()
+def _global_options(
+    verbose: bool = typer.Option(False, "--verbose", help="enable verbose output"),
+) -> None:
+    """Global options that may be ignored for now."""
+    if not verbose:
+        return
+    # No structured verbosity yet; placeholder for future diagnostics
+
+
+@app.command()
+def scan(
+    dirs: list[pathlib.Path] = typer.Argument(
+        ..., exists=True, readable=True, file_okay=False
+    )
+) -> None:
+    """Scan directories and report file count."""
+    try:
+        files = scan_paths(dirs)
+        print(f"[green]{len(files)} files found.[/green]")
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def report(
+    dirs: list[pathlib.Path] = typer.Argument(
+        ..., exists=True, readable=True, file_okay=False
+    ),
+    dest: pathlib.Path = typer.Option(
+        None, "--dest", file_okay=False, dir_okay=True
+    ),
+    auto_open: bool = typer.Option(False, "--auto-open", help="open XLSX when done"),
+) -> None:
+    """Generate an Excel report describing proposed moves."""
+    try:
+        files = scan_paths(dirs)
+        mapping: list[tuple[pathlib.Path, pathlib.Path]] = []
+        base = dest or pathlib.Path.cwd()
+        for f in files:
+            cat = classify(f) or "Unsorted"
+            target_dir = base / cat
+            mapping.append((f, generate_name(f, target_dir)))
+
+        out = build_report(mapping, auto_open=auto_open)
+        print(f"[bold]Report ready:[/bold] {out}")
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def review(
+    dirs: list[pathlib.Path] = typer.Argument(
+        ..., exists=True, readable=True, file_okay=False
+    )
+) -> None:
+    """Add files to review queue and list any due today."""
+    try:
+        files = scan_paths(dirs)
+        queue = ReviewQueue()
+        queue.upsert_files(files)
+        due = queue.select_for_review(limit=5)
+        if not due:
+            print("[green]No files pending review.[/green]")
+            return
+        print("[bold]Files to review:[/bold]")
+        for p in due:
+            print(f"  • {p}")
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def move(
+    dirs: list[pathlib.Path] = typer.Argument(
+        ..., exists=True, readable=True, file_okay=False
+    ),
+    dest: pathlib.Path = typer.Option(..., "--dest", file_okay=False, dir_okay=True),
+    yes: bool = typer.Option(False, "--yes", help="skip confirmation"),
+    dry_run: bool = typer.Option(True, "--dry-run/--no-dry-run"),
+) -> None:
+    """Scan, classify and move files into *dest*."""
+    try:
+        files = scan_paths(dirs)
+        mapping: list[tuple[pathlib.Path, pathlib.Path]] = []
+        for f in files:
+            cat = classify(f) or "Unsorted"
+            target_dir = dest / cat
+            mapping.append((f, generate_name(f, target_dir)))
+
+        report_path = build_report(mapping, auto_open=False)
+        print(f"[bold]Report ready:[/bold] {report_path}")
+        if dry_run:
+            print("[yellow]Dry-run complete — no files moved.[/yellow]")
+            return
+        if not yes and not typer.confirm("Proceed with move?"):
+            return
+        log_path = move_with_log(mapping)
+        print(f"[green]Move done.[/green] Log: {log_path}")
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command()
+def undo(log_file: pathlib.Path = typer.Argument(..., exists=True, readable=True)) -> None:
+    """Undo file moves recorded in *log_file*."""
+    try:
+        rollback(log_file)
+        print("[green]Rollback complete.[/green]")
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[red]{exc}[/red]")
+        raise typer.Exit(1)
+
+
+# Existing commands -------------------------------------------------------
+
+
+@app.command()
 def dupes(
     dirs: list[pathlib.Path] = typer.Argument(..., exists=True, readable=True),
     delete_older: bool = typer.Option(False, help="auto-delete older copies"),
-    hardlink: bool = typer.Option(False, help="replace duplicates with hardlink"),
+    hardlink: bool = typer.Option(
+        False, help="replace duplicates with hardlink"
+    ),
 ) -> None:
+    """Find duplicate files by SHA-256 hash."""
     files = scan_paths(dirs)
     groups = find_duplicates(files)
     if not groups:
         print("[green]No duplicates detected.")
-        raise typer.Exit()
+        return
     for digest, paths in groups.items():
         print(f"[bold yellow]{len(paths)}×[/bold yellow] {digest[:10]} →")
         for p in paths:
@@ -34,7 +165,7 @@ def dupes(
         print("⚠️  hardlink requires delete_older to leave single copy.")
 
 
-@app.command()  # type: ignore[misc]
+@app.command()
 def schedule(
     cron: str = typer.Option("0 3 * * *", help="cron expression"),
     dirs: list[pathlib.Path] = typer.Argument(...),
@@ -48,7 +179,7 @@ def schedule(
     print("[green]Scheduler entry installed.[/green]")
 
 
-@app.command()  # type: ignore[misc]
+@app.command()
 def stats(
     logs_dir: pathlib.Path = typer.Argument(..., dir_okay=True),
     out: pathlib.Path = typer.Option(None, "--out", file_okay=True),
@@ -64,9 +195,10 @@ def stats(
     print(f"[green]Dashboard written to {dash}[/green]")
 
 
-def main() -> None:
+def main() -> None:  # pragma: no cover - manual execution
     app()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     main()
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 from typer.testing import CliRunner
 
-from sorter.cli import app
+from sorter import app
 
 
 def test_dupes_command(tmp_path, monkeypatch):
@@ -62,3 +62,21 @@ def test_stats_command(tmp_path, monkeypatch):
     result = runner.invoke(app, ["stats", str(tmp_path), "--out", str(dest)])
     assert result.exit_code == 0
     assert calls["dash"] == ([log], dest)
+
+
+def test_scan_smoke(tmp_path):
+    (tmp_path / "a.txt").write_text("x")
+    runner = CliRunner()
+    result = runner.invoke(app, ["scan", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "1" in result.stdout
+
+
+def test_move_dry_run(tmp_path, monkeypatch):
+    (tmp_path / "a.txt").write_text("x")
+    monkeypatch.setattr("sorter.cli.build_report", lambda *a, **k: tmp_path / "rep.xlsx")
+    dest = tmp_path / "dest"
+    runner = CliRunner()
+    result = runner.invoke(app, ["move", str(tmp_path), "--dest", str(dest)])
+    assert result.exit_code == 0
+    assert "Dry-run" in result.stdout


### PR DESCRIPTION
## Summary
- add Typer-based command line interface with scan, report, review, move and undo commands
- export `app` from package
- expose `file-sorter` script entry
- extend CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b7014f6883229065a841c3079aee