### PR TITLE
Format CLI and tests with black

### DIFF
--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -48,9 +48,7 @@ def report(
     dirs: list[pathlib.Path] = typer.Argument(
         ..., exists=True, readable=True, file_okay=False
     ),
-    dest: pathlib.Path = typer.Option(
-        None, "--dest", file_okay=False, dir_okay=True
-    ),
+    dest: pathlib.Path = typer.Option(None, "--dest", file_okay=False, dir_okay=True),
     auto_open: bool = typer.Option(False, "--auto-open", help="open XLSX when done"),
 ) -> None:
     """Generate an Excel report describing proposed moves."""
@@ -126,7 +124,9 @@ def move(
 
 
 @app.command()
-def undo(log_file: pathlib.Path = typer.Argument(..., exists=True, readable=True)) -> None:
+def undo(
+    log_file: pathlib.Path = typer.Argument(..., exists=True, readable=True)
+) -> None:
     """Undo file moves recorded in *log_file*."""
     try:
         rollback(log_file)
@@ -143,9 +143,7 @@ def undo(log_file: pathlib.Path = typer.Argument(..., exists=True, readable=True
 def dupes(
     dirs: list[pathlib.Path] = typer.Argument(..., exists=True, readable=True),
     delete_older: bool = typer.Option(False, help="auto-delete older copies"),
-    hardlink: bool = typer.Option(
-        False, help="replace duplicates with hardlink"
-    ),
+    hardlink: bool = typer.Option(False, help="replace duplicates with hardlink"),
 ) -> None:
     """Find duplicate files by SHA-256 hash."""
     files = scan_paths(dirs)
@@ -201,4 +199,3 @@ def main() -> None:  # pragma: no cover - manual execution
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     main()
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,7 +74,9 @@ def test_scan_smoke(tmp_path):
 
 def test_move_dry_run(tmp_path, monkeypatch):
     (tmp_path / "a.txt").write_text("x")
-    monkeypatch.setattr("sorter.cli.build_report", lambda *a, **k: tmp_path / "rep.xlsx")
+    monkeypatch.setattr(
+        "sorter.cli.build_report", lambda *a, **k: tmp_path / "rep.xlsx"
+    )
     dest = tmp_path / "dest"
     runner = CliRunner()
     result = runner.invoke(app, ["move", str(tmp_path), "--dest", str(dest)])

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -13,14 +13,21 @@ def test_invalid_cron(expr):
     with pytest.raises(ValueError):
         validate_cron(expr)
 
+
 from sorter import scheduler
 
 
 def test_install_job_linux(monkeypatch, tmp_path):
     called = {}
     monkeypatch.setattr(scheduler.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(scheduler, "_install_cron", lambda c, cmd: called.setdefault("cron", (c, cmd)))
-    monkeypatch.setattr(scheduler, "_install_windows", lambda c, cmd: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(
+        scheduler, "_install_cron", lambda c, cmd: called.setdefault("cron", (c, cmd))
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_install_windows",
+        lambda c, cmd: (_ for _ in ()).throw(AssertionError()),
+    )
 
     scheduler.install_job("0 1 * * *", dirs=[tmp_path], dest=tmp_path / "d")
     assert called["cron"][0] == "0 1 * * *"
@@ -29,8 +36,14 @@ def test_install_job_linux(monkeypatch, tmp_path):
 def test_install_job_windows(monkeypatch, tmp_path):
     called = {}
     monkeypatch.setattr(scheduler.platform, "system", lambda: "Windows")
-    monkeypatch.setattr(scheduler, "_install_windows", lambda c, cmd: called.setdefault("win", (c, cmd)))
-    monkeypatch.setattr(scheduler, "_install_cron", lambda c, cmd: (_ for _ in ()).throw(AssertionError()))
+    monkeypatch.setattr(
+        scheduler, "_install_windows", lambda c, cmd: called.setdefault("win", (c, cmd))
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_install_cron",
+        lambda c, cmd: (_ for _ in ()).throw(AssertionError()),
+    )
 
     scheduler.install_job("0 2 * * *", dirs=[tmp_path], dest=tmp_path / "d")
     assert called["win"][0] == "0 2 * * *"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -9,6 +9,7 @@ def test_import_without_dsn(monkeypatch):
     if "sentry_sdk" in sys.modules:
         del sys.modules["sentry_sdk"]
     import sorter.telemetry as tel
+
     importlib.reload(tel)
 
 
@@ -22,5 +23,6 @@ def test_import_with_dsn(monkeypatch):
     monkeypatch.setenv("FILE_SORTER_SENTRY_DSN", "abc")
     monkeypatch.setitem(sys.modules, "sentry_sdk", FakeSdk())
     import sorter.telemetry as tel
+
     importlib.reload(tel)
     assert events == [("abc", 0.0)]


### PR DESCRIPTION
## Summary
- reformat CLI and test modules with `black`

## Testing
- `black --check .`

------
https://chatgpt.com/codex/tasks/task_e_6844dcb87e84832299154a017ed6531c