### PR TITLE
Enable mypy on push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: v1.16.0
     hooks:
       - id: mypy
+        stages: [commit, push]
         additional_dependencies: [types-setuptools]
         args: [--ignore-missing-imports]
   - repo: local

--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ file-sorter stats ~/Downloads
 Set up pre-commit hooks to automatically run formatting and tests:
 ```bash
 pre-commit install
+pre-commit install -t pre-push
 ```
-After installation, the following checks run on each commit:
+After installation, the following checks run on each commit and push:
 - **black** for code formatting
 - **flake8** for linting
-- **mypy** for type checking
+- **mypy** for type checking (commit and push)
 - **pytest** for unit tests
 - **poetry lock** to update dependencies when `pyproject.toml` changes


### PR DESCRIPTION
## Summary
- run mypy hook on commit and push
- document new pre-push hook in README

## Testing
- `poetry install --with dev`
- `poetry run pytest`
- `poetry run mypy sorter tests`


------
https://chatgpt.com/codex/tasks/task_e_6844f3d3a84883229af9d8ffd8ff2185