### PR TITLE
Add EXIF and ID3 renamer plugins

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,5 +7,9 @@ extensions = [".jpg", ".jpeg", ".png", ".gif"]
 extensions = [".mp4", ".mov", ".avi"]
 
 [plugins.exif_renamer]
-enabled = false
-pattern = "{year}{month}{day}_{hour}{minute}{second}"
+enabled = true
+pattern = "{year}-{month}-{day}_{hour}.{minute}.{second}_{model}"
+
+[plugins.id3_renamer]
+enabled = true
+pattern = "{artist} - {album} - {track_number:02d} - {title}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ croniter = "^6.0.0"
 python-dateutil = "^2.9.0.post0"
 typer = "^0.16.0"
 ExifRead = "*"
+mutagen = "*"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.11.13"

--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -113,9 +113,16 @@ def move(
             cat = classify(f, config) or "Unsorted"
             target_dir = dest / cat
 
-            new_name_from_plugin = plugin_manager.rename_with_plugin(f)
-            if new_name_from_plugin:
-                final_dest = target_dir / new_name_from_plugin
+            new_stem_from_plugin = plugin_manager.rename_with_plugin(f)
+
+            if new_stem_from_plugin:
+                temp = f.with_stem(new_stem_from_plugin)
+                final_dest = generate_name(
+                    temp,
+                    target_dir,
+                    include_parent=False,
+                    date_from_mtime=False,
+                )
             else:
                 final_dest = generate_name(f, target_dir)
 

--- a/sorter/plugin_manager.py
+++ b/sorter/plugin_manager.py
@@ -1,7 +1,7 @@
 import importlib
 import pkgutil
 import pathlib
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 
 import sorter.plugins
 from sorter.plugins.base import RenamerPlugin
@@ -9,25 +9,27 @@ from sorter.plugins.base import RenamerPlugin
 
 class PluginManager:
     def __init__(self, config: Dict[str, Any]):
-        self.config = config.get("plugins", {})
-        self._plugins = self._load_plugins()
+        self.plugin_config = config.get("plugins", {})
+        self.renamer_plugins: List[RenamerPlugin] = self._load_plugins()
 
-    def _load_plugins(self) -> Dict[str, RenamerPlugin]:
-        loaded_plugins = {}
+    def _load_plugins(self) -> List[RenamerPlugin]:
+        """Dynamically load enabled renamer plugins."""
+        loaded: List[RenamerPlugin] = []
         for finder, name, ispkg in pkgutil.iter_modules(sorter.plugins.__path__):
             if name == "base":
                 continue
             module = importlib.import_module(f"sorter.plugins.{name}")
-            plugin_config = self.config.get(name, {})
             if hasattr(module, "Plugin"):
+                plugin_config = self.plugin_config.get(name, {})
                 plugin_instance = module.Plugin(plugin_config)
-                if plugin_instance.enabled:
-                    loaded_plugins[name] = plugin_instance
-        return loaded_plugins
+                if isinstance(plugin_instance, RenamerPlugin) and plugin_instance.enabled:
+                    loaded.append(plugin_instance)
+        return loaded
 
-    def rename_with_plugin(self, source_path: pathlib.Path) -> Optional[pathlib.Path]:
-        for plugin in self._plugins.values():
-            new_name = plugin.rename(source_path)
-            if new_name:
-                return new_name
+    def rename_with_plugin(self, source_path: pathlib.Path) -> Optional[str]:
+        """Try renaming *source_path* with the loaded plugins."""
+        for plugin in self.renamer_plugins:
+            new_stem = plugin.rename(source_path)
+            if new_stem:
+                return new_stem
         return None

--- a/sorter/plugins/base.py
+++ b/sorter/plugins/base.py
@@ -3,12 +3,13 @@ from typing import Dict, Any, Optional
 
 
 class RenamerPlugin:
-    """Base class for renamer plugins."""
+    """Base class for all renamer plugins."""
 
     def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.enabled = config.get("enabled", False)
+        self.pattern = config.get("pattern", "")
 
-    def rename(self, source_path: pathlib.Path) -> Optional[pathlib.Path]:
-        """Return a new Path or None if plugin does not apply."""
+    def rename(self, source_path: pathlib.Path) -> Optional[str]:
+        """Return a new sanitized stem or ``None`` if plugin does not apply."""
         raise NotImplementedError

--- a/sorter/plugins/exif_renamer.py
+++ b/sorter/plugins/exif_renamer.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 from typing import Optional
 
 import exifread
@@ -6,29 +7,40 @@ import exifread
 from .base import RenamerPlugin
 
 
+def sanitize_filename(name: str) -> str:
+    """Remove characters that are invalid for file names."""
+    return re.sub(r'[\\/*?:"<>|]', "", name)
+
+
 class Plugin(RenamerPlugin):
-    def rename(self, source_path: pathlib.Path) -> Optional[pathlib.Path]:
+    """Rename photos based on EXIF metadata."""
+
+    def rename(self, source_path: pathlib.Path) -> Optional[str]:
         if source_path.suffix.lower() not in [".jpg", ".jpeg", ".tiff"]:
             return None
 
         with source_path.open("rb") as f:
-            tags = exifread.process_file(f, details=False)
-            if "EXIF DateTimeOriginal" in tags:
-                dt_str = str(tags["EXIF DateTimeOriginal"])
-                year, month, day = dt_str[:10].split(":")
-                hour, minute, second = dt_str[11:].split(":")
-                pattern = self.config.get(
-                    "pattern",
-                    "{year}{month}{day}_{hour}{minute}{second}",
-                )
-                new_stem = pattern.format(
-                    year=year,
-                    month=month,
-                    day=day,
-                    hour=hour,
-                    minute=minute,
-                    second=second,
-                    model=str(tags.get("Image Model", "")),
-                )
-                return pathlib.Path(new_stem + source_path.suffix)
-        return None
+            tags = exifread.process_file(f, details=False, stop_tag="EXIF DateTimeOriginal")
+            if "EXIF DateTimeOriginal" not in tags:
+                return None
+
+            dt_str = str(tags["EXIF DateTimeOriginal"])
+            match = re.match(r"(\d{4}):(\d{2}):(\d{2}) (\d{2}):(\d{2}):(\d{2})", dt_str)
+            if not match:
+                return None
+
+            year, month, day, hour, minute, second = match.groups()
+
+            format_data = {
+                "year": year,
+                "month": month,
+                "day": day,
+                "hour": hour,
+                "minute": minute,
+                "second": second,
+                "model": str(tags.get("Image Model", "UnknownModel")).strip(),
+                "make": str(tags.get("Image Make", "UnknownMake")).strip(),
+            }
+
+            new_stem = self.pattern.format(**format_data)
+            return sanitize_filename(new_stem)

--- a/sorter/plugins/id3_renamer.py
+++ b/sorter/plugins/id3_renamer.py
@@ -1,0 +1,43 @@
+import pathlib
+import re
+from typing import Optional
+
+from mutagen.easyid3 import EasyID3
+from mutagen.flac import FLAC
+from mutagen.mp4 import MP4
+
+from .base import RenamerPlugin
+
+
+def sanitize_filename(name: str) -> str:
+    """Remove characters that are invalid for file names."""
+    return re.sub(r'[\\/*?:"<>|]', "", name)
+
+
+class Plugin(RenamerPlugin):
+    """Rename audio files based on ID3/FLAC/MP4 metadata."""
+
+    def rename(self, source_path: pathlib.Path) -> Optional[str]:
+        suffix = source_path.suffix.lower()
+        try:
+            if suffix == ".mp3":
+                audio = EasyID3(source_path)
+            elif suffix == ".flac":
+                audio = FLAC(source_path)
+            elif suffix == ".m4a":
+                audio = MP4(source_path)
+            else:
+                return None
+        except Exception:
+            return None
+
+        format_data = {
+            "artist": audio.get("artist", ["Unknown Artist"])[0],
+            "album": audio.get("album", ["Unknown Album"])[0],
+            "title": audio.get("title", [source_path.stem])[0],
+            "track_number": int(str(audio.get("tracknumber", ["0"])[0]).split("/")[0]),
+            "genre": audio.get("genre", ["Unknown Genre"])[0],
+        }
+
+        new_stem = self.pattern.format(**format_data)
+        return sanitize_filename(new_stem)


### PR DESCRIPTION
## Summary
- add `mutagen` dependency
- implement new `RenamerPlugin` base class
- enhance EXIF renamer and add ID3 renamer
- update plugin manager to load renamer plugins
- integrate metadata renaming in CLI move command
- expand sample config with plugin settings

## Testing
- `pip install pandas typer ExifRead mutagen openpyxl rich python-slugify python-magic croniter python-dateutil`
- `pip install matplotlib`
- `pip install pytest-benchmark`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fa754774832293fb87325a69e86f