### PR TITLE
Add EXIF & ID3 renamer plugins

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,5 +7,11 @@ extensions = [".jpg", ".jpeg", ".png", ".gif"]
 extensions = [".mp4", ".mov", ".avi"]
 
 [plugins.exif_renamer]
-enabled = false
-pattern = "{year}{month}{day}_{hour}{minute}{second}"
+enabled = true
+# Available tokens: {year}, {month}, {day}, {hour}, {minute}, {second}, {model}, {make}
+pattern = "{year}-{month}-{day}_{hour}.{minute}.{second}_{model}"
+
+[plugins.id3_renamer]
+enabled = true
+# Available tokens: {artist}, {album}, {title}, {track_number}, {genre}
+pattern = "{artist} - {album} - {track_number:02d} - {title}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1009,6 +1009,18 @@ files = [
 ]
 
 [[package]]
+name = "mutagen"
+version = "1.47.0"
+description = "read and write audio tags for many formats"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mutagen-1.47.0-py3-none-any.whl", hash = "sha256:edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719"},
+    {file = "mutagen-1.47.0.tar.gz", hash = "sha256:719fadef0a978c31b4cf3c956261b3c58b6948b32023078a2117b1de09f0fc99"},
+]
+
+[[package]]
 name = "mypy"
 version = "1.16.0"
 description = "Optional static typing for Python"
@@ -2324,4 +2336,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "544ff45e724559702e1529501e443122fdb0322f686d29d009294478567b3fe7"
+content-hash = "d6116b524bbd6edf8e78f6a41c8eebc0405b848a079ec84dab7ecf6497e65d52"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ croniter = "^6.0.0"
 python-dateutil = "^2.9.0.post0"
 typer = "^0.16.0"
 ExifRead = "*"
+mutagen = "*"
 scikit-learn = "*"
 joblib = "*"
 

--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -115,9 +115,16 @@ def move(
             cat = classify_file(f) or "Unsorted"
             target_dir = dest / cat
 
-            new_name_from_plugin = plugin_manager.rename_with_plugin(f)
-            if new_name_from_plugin:
-                final_dest = target_dir / new_name_from_plugin
+            new_stem_from_plugin = plugin_manager.rename_with_plugin(f)
+
+            if new_stem_from_plugin:
+                temp_path_for_collision_check = f.with_stem(new_stem_from_plugin)
+                final_dest = generate_name(
+                    temp_path_for_collision_check,
+                    target_dir,
+                    include_parent=False,
+                    date_from_mtime=False,
+                )
             else:
                 final_dest = generate_name(f, target_dir)
 

--- a/sorter/plugin_manager.py
+++ b/sorter/plugin_manager.py
@@ -1,7 +1,7 @@
 import importlib
 import pkgutil
 import pathlib
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 
 import sorter.plugins
 from sorter.plugins.base import RenamerPlugin
@@ -9,25 +9,26 @@ from sorter.plugins.base import RenamerPlugin
 
 class PluginManager:
     def __init__(self, config: Dict[str, Any]):
-        self.config = config.get("plugins", {})
-        self._plugins = self._load_plugins()
+        self.plugin_config = config.get("plugins", {})
+        self.renamer_plugins: List[RenamerPlugin] = self._load_plugins()
 
-    def _load_plugins(self) -> Dict[str, RenamerPlugin]:
-        loaded_plugins = {}
+    def _load_plugins(self) -> List[RenamerPlugin]:
+        """Dynamically loads all plugins that inherit from RenamerPlugin."""
+        loaded: List[RenamerPlugin] = []
         for finder, name, ispkg in pkgutil.iter_modules(sorter.plugins.__path__):
-            if name == "base":
-                continue
-            module = importlib.import_module(f"sorter.plugins.{name}")
-            plugin_config = self.config.get(name, {})
-            if hasattr(module, "Plugin"):
-                plugin_instance = module.Plugin(plugin_config)
-                if plugin_instance.enabled:
-                    loaded_plugins[name] = plugin_instance
-        return loaded_plugins
+            if name != "base":
+                module = importlib.import_module(f"sorter.plugins.{name}")
+                if hasattr(module, "Plugin"):
+                    plugin_config = self.plugin_config.get(name, {})
+                    plugin_instance = module.Plugin(plugin_config)
+                    if isinstance(plugin_instance, RenamerPlugin) and plugin_instance.enabled:
+                        loaded.append(plugin_instance)
+        return loaded
 
-    def rename_with_plugin(self, source_path: pathlib.Path) -> Optional[pathlib.Path]:
-        for plugin in self._plugins.values():
-            new_name = plugin.rename(source_path)
-            if new_name:
-                return new_name
+    def rename_with_plugin(self, source_path: pathlib.Path) -> Optional[str]:
+        """Tries to rename a file using the first successful plugin."""
+        for plugin in self.renamer_plugins:
+            new_stem = plugin.rename(source_path)
+            if new_stem:
+                return new_stem
         return None

--- a/sorter/plugin_manager.py
+++ b/sorter/plugin_manager.py
@@ -21,7 +21,8 @@ class PluginManager:
                 if hasattr(module, "Plugin"):
                     plugin_config = self.plugin_config.get(name, {})
                     plugin_instance = module.Plugin(plugin_config)
-                    if isinstance(plugin_instance, RenamerPlugin) and plugin_instance.enabled:
+                    is_renamer = isinstance(plugin_instance, RenamerPlugin)
+                    if is_renamer and plugin_instance.enabled:
                         loaded.append(plugin_instance)
         return loaded
 

--- a/sorter/plugins/base.py
+++ b/sorter/plugins/base.py
@@ -3,12 +3,13 @@ from typing import Dict, Any, Optional
 
 
 class RenamerPlugin:
-    """Base class for renamer plugins."""
+    """Base class for all renamer plugins."""
 
     def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.enabled = config.get("enabled", False)
+        self.pattern = config.get("pattern", "")
 
-    def rename(self, source_path: pathlib.Path) -> Optional[pathlib.Path]:
-        """Return a new Path or None if plugin does not apply."""
+    def rename(self, source_path: pathlib.Path) -> Optional[str]:
+        """Return a sanitized filename stem or ``None`` if plugin does not apply."""
         raise NotImplementedError

--- a/sorter/plugins/exif_renamer.py
+++ b/sorter/plugins/exif_renamer.py
@@ -21,13 +21,18 @@ class Plugin(RenamerPlugin):
             return None
 
         with source_path.open("rb") as f:
-            tags = exifread.process_file(f, details=False, stop_tag="EXIF DateTimeOriginal")
+            tags = exifread.process_file(
+                f, details=False, stop_tag="EXIF DateTimeOriginal"
+            )
 
             if "EXIF DateTimeOriginal" not in tags:
                 return None
 
             dt_str = str(tags["EXIF DateTimeOriginal"])
-            dt_parts = re.match(r"(\d{4}):(\d{2}):(\d{2}) (\d{2}):(\d{2}):(\d{2})", dt_str)
+            dt_parts = re.match(
+                r"(\d{4}):(\d{2}):(\d{2}) (\d{2}):(\d{2}):(\d{2})",
+                dt_str,
+            )
             if not dt_parts:
                 return None
 

--- a/sorter/plugins/exif_renamer.py
+++ b/sorter/plugins/exif_renamer.py
@@ -1,34 +1,48 @@
 import pathlib
-from typing import Optional
+import re
+from typing import Dict, Any, Optional
 
 import exifread
 
 from .base import RenamerPlugin
 
 
+def sanitize_filename(name: str) -> str:
+    """Remove characters that are invalid for file names."""
+    return re.sub(r'[\\/*?:"<>|]', "", name)
+
+
 class Plugin(RenamerPlugin):
-    def rename(self, source_path: pathlib.Path) -> Optional[pathlib.Path]:
+    """A renamer plugin for photos based on EXIF data."""
+
+    def rename(self, source_path: pathlib.Path) -> Optional[str]:
+        # This plugin only handles common image file types
         if source_path.suffix.lower() not in [".jpg", ".jpeg", ".tiff"]:
             return None
 
         with source_path.open("rb") as f:
-            tags = exifread.process_file(f, details=False)
-            if "EXIF DateTimeOriginal" in tags:
-                dt_str = str(tags["EXIF DateTimeOriginal"])
-                year, month, day = dt_str[:10].split(":")
-                hour, minute, second = dt_str[11:].split(":")
-                pattern = self.config.get(
-                    "pattern",
-                    "{year}{month}{day}_{hour}{minute}{second}",
-                )
-                new_stem = pattern.format(
-                    year=year,
-                    month=month,
-                    day=day,
-                    hour=hour,
-                    minute=minute,
-                    second=second,
-                    model=str(tags.get("Image Model", "")),
-                )
-                return pathlib.Path(new_stem + source_path.suffix)
-        return None
+            tags = exifread.process_file(f, details=False, stop_tag="EXIF DateTimeOriginal")
+
+            if "EXIF DateTimeOriginal" not in tags:
+                return None
+
+            dt_str = str(tags["EXIF DateTimeOriginal"])
+            dt_parts = re.match(r"(\d{4}):(\d{2}):(\d{2}) (\d{2}):(\d{2}):(\d{2})", dt_str)
+            if not dt_parts:
+                return None
+
+            year, month, day, hour, minute, second = dt_parts.groups()
+
+            format_data: Dict[str, Any] = {
+                "year": year,
+                "month": month,
+                "day": day,
+                "hour": hour,
+                "minute": minute,
+                "second": second,
+                "model": str(tags.get("Image Model", "UnknownModel")).strip(),
+                "make": str(tags.get("Image Make", "UnknownMake")).strip(),
+            }
+
+            new_stem = self.pattern.format(**format_data)
+            return sanitize_filename(new_stem)

--- a/sorter/plugins/id3_renamer.py
+++ b/sorter/plugins/id3_renamer.py
@@ -1,0 +1,44 @@
+import pathlib
+import re
+from typing import Optional
+
+from mutagen.easyid3 import EasyID3
+from mutagen.flac import FLAC
+from mutagen.mp4 import MP4
+
+from .base import RenamerPlugin
+
+
+def sanitize_filename(name: str) -> str:
+    """Remove characters that are invalid for file names."""
+    return re.sub(r'[\\/*?:"<>|]', "", name)
+
+
+class Plugin(RenamerPlugin):
+    """A renamer plugin for audio files based on ID3, MP4, or FLAC tags."""
+
+    def rename(self, source_path: pathlib.Path) -> Optional[str]:
+        suffix = source_path.suffix.lower()
+
+        try:
+            if suffix == ".mp3":
+                audio = EasyID3(source_path)
+            elif suffix == ".flac":
+                audio = FLAC(source_path)
+            elif suffix == ".m4a":
+                audio = MP4(source_path)
+            else:
+                return None
+        except Exception:
+            return None
+
+        format_data = {
+            "artist": audio.get("artist", ["Unknown Artist"])[0],
+            "album": audio.get("album", ["Unknown Album"])[0],
+            "title": audio.get("title", [source_path.stem])[0],
+            "track_number": int(audio.get("tracknumber", ["0"])[0].split("/")[0]),
+            "genre": audio.get("genre", ["Unknown Genre"])[0],
+        }
+
+        new_stem = self.pattern.format(**format_data)
+        return sanitize_filename(new_stem)

--- a/sorter/plugins/id3_renamer.py
+++ b/sorter/plugins/id3_renamer.py
@@ -1,6 +1,6 @@
 import pathlib
 import re
-from typing import Optional
+from typing import Optional, Any
 
 from mutagen.easyid3 import EasyID3
 from mutagen.flac import FLAC
@@ -20,6 +20,7 @@ class Plugin(RenamerPlugin):
     def rename(self, source_path: pathlib.Path) -> Optional[str]:
         suffix = source_path.suffix.lower()
 
+        audio: Any
         try:
             if suffix == ".mp3":
                 audio = EasyID3(source_path)


### PR DESCRIPTION
## Summary
- update config defaults for EXIF and ID3 renamer plugins
- support metadata renaming via plugins
- extend PluginManager to load RenamerPlugin subclasses
- hook plugin renamer logic into CLI move command
- add mutagen dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fe313994832290766f6c9d413edd