### PR TITLE
Fix mypy checks in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 on: [push, pull_request]
+
 jobs:
-  lint-test:
+  lint:
+    name: "Lint / flake8"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -11,5 +13,27 @@ jobs:
       - run: pip install poetry
       - run: poetry install --with dev
       - run: poetry run flake8
+
+  type-check:
+    name: "Type Check / mypy"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install poetry
+      - run: poetry install --with dev
       - run: poetry run mypy sorter tests
+
+  test:
+    name: "Test / pytest"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install poetry
+      - run: poetry install --with dev
       - run: poetry run pytest


### PR DESCRIPTION
## Summary
- split lint, mypy, and pytest steps into distinct jobs

## Testing
- `poetry install --with dev`
- `poetry run pytest`
- `poetry run flake8`
- `poetry run mypy sorter tests`


------
https://chatgpt.com/codex/tasks/task_e_6845055f91d88322a2cce822a0e7a376