### PR TITLE
Add tests for classify_file logic

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2333,7 +2333,10 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "importlib_resources ; python_version < \"3.9\"", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
+[extras]
+dev = []
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "d6116b524bbd6edf8e78f6a41c8eebc0405b848a079ec84dab7ecf6497e65d52"
+content-hash = "49c766c5e27072086362bc70c21bd5b826de503130ee9246c1dc02c3a4cfbaae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,19 @@ pytest-cov = "^5.0.0"
 pytest-benchmark = "^5.1.0"
 matplotlib = "^3.8.0"
 
+[tool.poetry.extras]
+dev = [
+    "ruff",
+    "black",
+    "mypy",
+    "flake8",
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+    "pytest-benchmark",
+    "matplotlib",
+]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_classify_file.py
+++ b/tests/test_classify_file.py
@@ -7,7 +7,7 @@ def test_supervised_prediction(tmp_path, monkeypatch):
     f.write_text("x")
 
     monkeypatch.setattr("sorter.supervised.predict_category", lambda p: "Docs")
-    monkeypatch.setattr("sorter.config.load_config", lambda: {})
+    monkeypatch.setattr("sorter.classifier.load_config", lambda: {})
 
     assert classify_file(f) == "Docs"
 
@@ -18,7 +18,7 @@ def test_rule_based(tmp_path, monkeypatch):
 
     monkeypatch.setattr("sorter.supervised.predict_category", lambda p: None)
     monkeypatch.setattr(
-        "sorter.config.load_config",
+        "sorter.classifier.load_config",
         lambda: {"classification": {"Pictures": {"extensions": [".jpg"]}}},
     )
 
@@ -35,7 +35,9 @@ def test_cluster_label(tmp_path, monkeypatch):
     labels_path.write_text(json.dumps({"1": "Music"}))
 
     monkeypatch.setattr("sorter.supervised.predict_category", lambda p: None)
-    monkeypatch.setattr("sorter.config.load_config", lambda: {"fallback_category": None})
+    monkeypatch.setattr(
+        "sorter.classifier.load_config", lambda: {"fallback_category": None}
+    )
     monkeypatch.setattr("sorter.classifier.classify", lambda p, c: None)
     monkeypatch.setattr("sorter.clustering.MODEL_PATH", model_path)
     monkeypatch.setattr("sorter.clustering.LABELS_PATH", labels_path)
@@ -49,7 +51,9 @@ def test_unsorted(tmp_path, monkeypatch):
     f.write_bytes(b"x")
 
     monkeypatch.setattr("sorter.supervised.predict_category", lambda p: None)
-    monkeypatch.setattr("sorter.config.load_config", lambda: {"fallback_category": None})
+    monkeypatch.setattr(
+        "sorter.classifier.load_config", lambda: {"fallback_category": None}
+    )
     monkeypatch.setattr("sorter.classifier.classify", lambda p, c: None)
     monkeypatch.setattr("sorter.clustering.MODEL_PATH", tmp_path / "no_model")
     monkeypatch.setattr("sorter.clustering.LABELS_PATH", tmp_path / "no_labels")


### PR DESCRIPTION
## Summary
- ensure classify_file respects supervised predictions
- verify rule-based classification paths
- emulate clustering fallback when a stored label exists
- test Unsorted result when no predictions or rules are present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_6845096da74c83229c7f0b126ba554b6