### PR TITLE
Add --version option to CLI

### DIFF
--- a/sorter/__init__.py
+++ b/sorter/__init__.py
@@ -9,6 +9,8 @@ needed objects on first access.
 from importlib import import_module
 from typing import Any, Dict, Tuple
 
+__version__ = "1.0.0"
+
 _EXPORTS: Dict[str, Tuple[str, str]] = {
     "scan_paths": ("scanner", "scan_paths"),
     "find_duplicates": ("dupes", "find_duplicates"),
@@ -52,4 +54,5 @@ __all__ = [
     "rollback",
     "build_dashboard",
     "app",
+    "__version__",
 ]

--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -5,6 +5,7 @@ import json
 
 import typer
 import logging
+from . import __version__
 
 from .logging_config import setup_logging
 from .scanner import scan_paths
@@ -27,10 +28,24 @@ app = typer.Typer(
 log = logging.getLogger(__name__)
 
 
-@app.callback()
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
+@app.callback(invoke_without_command=True)
 def _global_options(
+    ctx: typer.Context,
     verbose: bool = typer.Option(
         False, "-v", "--verbose", help="Enable verbose DEBUG level logging."
+    ),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the application version and exit.",
     ),
 ) -> None:
     """Global options for the file-sorter CLI."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,3 +130,10 @@ def test_move_destination_exists(tmp_path, monkeypatch):
     )
     assert result.exit_code == 1
     assert "destination already exists" in result.stdout
+
+
+def test_version_option():
+    runner = CliRunner()
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "1.0.0" in result.stdout


### PR DESCRIPTION
## Summary
- expose package version as `__version__`
- implement `--version` global flag in the CLI
- test that `--version` outputs program version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452b0cebec83229f61f80fe0fc2130