### PR TITLE
Add customizable rename patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ pip install file-sorter
 file-sorter move ~/Downloads --dest ~/Sorted --dry-run
 ```
 
+### Custom naming patterns
+Use the ``--pattern`` option to change how files are renamed. Supported tokens
+include ``{parent}``, ``{date}``, ``{stem}`` and ``{ext}``.
+```bash
+file-sorter move ~/Downloads --dest ~/Sorted --pattern "{date}-{stem}{ext}"
+```
+
 The classifier now recognizes a wide range of common file types out of the box.
 Pictures, videos, documents, spreadsheets, presentations, archives, scripts and
 more are automatically sorted into matching folders.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -13,6 +13,14 @@ File-Sorter reads rules from `default_rules.toml`. Copy it and modify as needed.
 file-sorter move ~/Downloads --dest ~/Sorted --dry-run
 ```
 
+### Custom naming patterns
+You can customize how files are renamed using the ``--pattern`` option. The
+pattern can contain ``{parent}``, ``{date}``, ``{stem}`` and ``{ext}`` tokens.
+For example:
+```bash
+file-sorter move ~/Downloads --dest ~/Sorted --pattern "{date}-{stem}{ext}"
+```
+
 ## Analytics
 After moving files you can generate a dashboard:
 ```bash

--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -93,6 +93,7 @@ def report(
         ..., exists=True, readable=True, file_okay=False
     ),
     dest: pathlib.Path = typer.Option(None, "--dest", file_okay=False, dir_okay=True),
+    pattern: str | None = typer.Option(None, "--pattern", help="rename pattern"),
     auto_open: bool = typer.Option(False, "--auto-open", help="open XLSX when done"),
 ) -> None:
     """Generate an Excel report describing proposed moves."""
@@ -105,7 +106,7 @@ def report(
         for f in files:
             cat = classify_file(f) or "Unsorted"
             target_dir = base / cat
-            new_path = generate_name(f, target_dir)
+            new_path = generate_name(f, target_dir, pattern=pattern)
             mapping.append((f, new_path))
             log.debug("map %s -> %s", f, new_path)
 
@@ -160,6 +161,7 @@ def move(
         ..., exists=True, readable=True, file_okay=False
     ),
     dest: pathlib.Path = typer.Option(..., "--dest", file_okay=False, dir_okay=True),
+    pattern: str | None = typer.Option(None, "--pattern", help="rename pattern"),
     yes: bool = typer.Option(False, "--yes", help="skip confirmation"),
     dry_run: bool = typer.Option(True, "--dry-run/--no-dry-run"),
 ) -> None:
@@ -184,9 +186,10 @@ def move(
                     target_dir,
                     include_parent=False,
                     date_from_mtime=False,
+                    pattern=pattern,
                 )
             else:
-                final_dest = generate_name(f, target_dir)
+                final_dest = generate_name(f, target_dir, pattern=pattern)
 
             mapping.append((f, final_dest))
             log.debug("plan move %s -> %s", f, final_dest)

--- a/tests/test_renamer.py
+++ b/tests/test_renamer.py
@@ -38,3 +38,11 @@ def test_case_insensitive_collision(tmp_path):
     (dest / "upper.txt").write_text("lowercase duplicate")
     result = generate_name(src, dest)
     assert result.name != "upper.txt" and result.name.lower() != "upper.txt"
+
+
+def test_custom_pattern(tmp_path):
+    src = _touch(tmp_path / "pics", "Holiday Photo.JPG", mtime=946684800)
+    dest = tmp_path / "out"
+    pat = "{date}-{stem}{ext}"
+    new_path = generate_name(src, dest, pattern=pat)
+    assert new_path.name.startswith("2000-01-01-holiday-photo")


### PR DESCRIPTION
## Summary
- support user-supplied patterns in `generate_name`
- expose `--pattern` in CLI `move` and `report`
- document custom patterns in README and user guide
- test pattern option for CLI and renamer

## Testing
- `pre-commit run --files sorter/renamer.py sorter/cli.py tests/test_cli.py tests/test_renamer.py README.md docs/user_guide.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684530104f0c8322b79705c1b64d5717