### PR TITLE
Add CSV and JSON report formats

### DIFF
--- a/sorter/cli.py
+++ b/sorter/cli.py
@@ -94,9 +94,10 @@ def report(
     ),
     dest: pathlib.Path = typer.Option(None, "--dest", file_okay=False, dir_okay=True),
     pattern: str | None = typer.Option(None, "--pattern", help="rename pattern"),
-    auto_open: bool = typer.Option(False, "--auto-open", help="open XLSX when done"),
+    auto_open: bool = typer.Option(False, "--auto-open", help="open report when done"),
+    fmt: str = typer.Option("xlsx", "--format", help="output format: xlsx, csv, json"),
 ) -> None:
-    """Generate an Excel report describing proposed moves."""
+    """Generate a report describing proposed moves."""
     try:
         log.debug("Generating report from %d source dirs", len(dirs))
         files = scan_paths(dirs)
@@ -110,7 +111,7 @@ def report(
             mapping.append((f, new_path))
             log.debug("map %s -> %s", f, new_path)
 
-        out = build_report(mapping, auto_open=auto_open)
+        out = build_report(mapping, auto_open=auto_open, fmt=fmt)
         log.info("Report ready: %s", out)
     except ModuleNotFoundError as exc:
         log.error(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,6 +174,30 @@ def test_move_destination_exists(tmp_path, monkeypatch):
     assert "destination already exists" in result.stdout
 
 
+def test_report_format_option(tmp_path, monkeypatch):
+    src = tmp_path / "a.txt"
+    src.write_text("x")
+
+    monkeypatch.setattr("sorter.cli.scan_paths", lambda dirs: [src])
+    monkeypatch.setattr("sorter.cli.classify_file", lambda p: None)
+    monkeypatch.setattr(
+        "sorter.cli.generate_name", lambda *a, **k: tmp_path / "dest" / "a.txt"
+    )
+
+    captured = {}
+
+    def fake_build_report(mapping, *, auto_open=False, fmt="xlsx"):
+        captured["fmt"] = fmt
+        return tmp_path / f"rep.{fmt}"
+
+    monkeypatch.setattr("sorter.cli.build_report", fake_build_report)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["report", str(tmp_path), "--format", "json"])
+    assert result.exit_code == 0
+    assert captured["fmt"] == "json"
+
+
 def test_version_option():
     runner = CliRunner()
     result = runner.invoke(app, ["--version"])

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -24,3 +24,25 @@ def test_report_content(tmp_path: pathlib.Path) -> None:
     assert list(df.columns) == ["old_path", "new_path", "size_bytes", "modified_iso"]
     assert df.shape == (2, 4)
     assert set(df["size_bytes"]) == {3, 6}
+
+
+def test_report_csv(tmp_path: pathlib.Path) -> None:
+    src = _create(tmp_path, "a.txt")
+    dst = tmp_path / "Docs" / "a.txt"
+
+    csv_path = build_report([(src, dst)], dest=tmp_path / "out.csv", fmt="csv")
+    assert csv_path.exists()
+
+    df = pd.read_csv(csv_path)
+    assert list(df.columns) == ["old_path", "new_path", "size_bytes", "modified_iso"]
+
+
+def test_report_json(tmp_path: pathlib.Path) -> None:
+    src = _create(tmp_path, "a.txt")
+    dst = tmp_path / "Docs" / "a.txt"
+
+    jsn_path = build_report([(src, dst)], dest=tmp_path / "out.json", fmt="json")
+    assert jsn_path.exists()
+
+    df = pd.read_json(jsn_path)
+    assert list(df.columns) == ["old_path", "new_path", "size_bytes", "modified_iso"]


### PR DESCRIPTION
## Summary
- support additional output formats for reports (CSV, JSON)
- update CLI to select report format
- extend reporter tests for new formats
- add CLI test for `--format`

## Testing
- `black sorter/reporter.py sorter/cli.py tests/test_reporter.py tests/test_cli.py`
- `flake8 sorter/reporter.py sorter/cli.py tests/test_reporter.py tests/test_cli.py`
- `mypy sorter/reporter.py sorter/cli.py tests/test_reporter.py tests/test_cli.py`
- `pytest tests/test_reporter.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_684532627ad883228afb0730dc7c8681