### PR TITLE
Refactor sanitize_filename utility

### DIFF
--- a/sorter/plugins/exif_renamer.py
+++ b/sorter/plugins/exif_renamer.py
@@ -5,11 +5,7 @@ from typing import Dict, Any, Optional
 import exifread
 
 from .base import RenamerPlugin
-
-
-def sanitize_filename(name: str) -> str:
-    """Remove characters that are invalid for file names."""
-    return re.sub(r'[\\/*?:"<>|]', "", name)
+from ..utils import sanitize_filename
 
 
 class Plugin(RenamerPlugin):

--- a/sorter/plugins/id3_renamer.py
+++ b/sorter/plugins/id3_renamer.py
@@ -7,11 +7,7 @@ from mutagen.flac import FLAC
 from mutagen.mp4 import MP4
 
 from .base import RenamerPlugin
-
-
-def sanitize_filename(name: str) -> str:
-    """Remove characters that are invalid for file names."""
-    return re.sub(r'[\\/*?:"<>|]', "", name)
+from ..utils import sanitize_filename
 
 
 class Plugin(RenamerPlugin):

--- a/sorter/utils.py
+++ b/sorter/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import pathlib
+import re
 from typing import Final
 
 BUF_SIZE: Final = 1 << 20  # 1 MiB
@@ -23,4 +24,10 @@ def sha256sum(path: pathlib.Path, *, buf_size: int = BUF_SIZE) -> str:
     return hash_file(path, algorithm="sha256", buf_size=buf_size)
 
 
-__all__ = ["hash_file", "sha256sum", "BUF_SIZE"]
+
+def sanitize_filename(name: str) -> str:
+    """Remove characters that are invalid for file names."""
+    return re.sub(r'[\\/*?:"<>|]', "", name)
+
+
+__all__ = ["hash_file", "sha256sum", "BUF_SIZE", "sanitize_filename"]


### PR DESCRIPTION
## Summary
- move `sanitize_filename` helper into `sorter.utils`
- import utility in both plugin modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457e9993e08322bcaa9aab287f621f