### PR TITLE
Refactor CLI with argparse subcommands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,4 +67,4 @@ ignore_missing_imports = true
 
 [tool.poetry.scripts]
 file-sorter-gui = "sorter_gui.app:main"
-file-sorter = "sorter.cli:app"
+file-sorter = "sorter.cli:main"

--- a/sorter/__init__.py
+++ b/sorter/__init__.py
@@ -26,7 +26,8 @@ _EXPORTS: Dict[str, Tuple[str, str]] = {
     "plan_moves": ("planner", "plan_moves"),
     "rollback": ("rollback", "rollback"),
     "build_dashboard": ("stats", "build_dashboard"),
-    "app": ("cli", "app"),
+    "get_parser": ("cli", "get_parser"),
+    "main": ("cli", "main"),
 }
 
 
@@ -57,6 +58,7 @@ __all__ = [
     "find_duplicates",
     "rollback",
     "build_dashboard",
-    "app",
+    "get_parser",
+    "main",
     "__version__",
 ]

--- a/sorter/cli_utils.py
+++ b/sorter/cli_utils.py
@@ -1,12 +1,14 @@
 import functools
 import logging
-import typer
+
+
+__all__ = ["handle_cli_errors"]
 
 log = logging.getLogger(__name__)
 
 
 def handle_cli_errors(func):
-    """Wrap Typer command functions with common error handling."""
+    """Wrap command functions with common error handling."""
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -14,34 +16,26 @@ def handle_cli_errors(func):
             return func(*args, **kwargs)
         except FileExistsError as exc:
             msg = f"Move aborted: destination already exists ({exc})"
-            log.error(msg)
-            typer.echo(msg)
         except FileNotFoundError as exc:
-            msg = f"Log file not found: {exc}"
-            log.error(msg)
-            typer.echo(msg)
+            msg = f"File not found: {exc}"
         except ModuleNotFoundError as exc:
             msg = (
                 f"Missing dependency '{exc.name}'. Install optional extras "
                 "to use this command."
             )
-            log.error(msg)
-            typer.echo(msg)
         except PermissionError as exc:
             msg = f"Permission denied: {exc}"
-            log.error(msg)
-            typer.echo(msg)
         except ValueError as exc:
             msg = str(exc)
-            log.error(msg)
-            typer.echo(msg)
         except Exception as exc:  # pragma: no cover - defensive
             log.exception("Unexpected error: %s", exc)
+            raise SystemExit(1) from exc
         else:
             return
-        raise typer.Exit(1)
+
+        log.error(msg)
+        print(msg)
+        raise SystemExit(1)
 
     return wrapper
 
-
-__all__ = ["handle_cli_errors"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,20 @@
 import sys
 from pathlib import Path
+import io
+import contextlib
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sorter.cli import main
+
+
+def run_cli(args):
+    buf = io.StringIO()
+    exit_code = 0
+    with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+        try:
+            main(args)
+        except SystemExit as e:
+            exit_code = int(e.code or 0)
+    return SimpleNamespace(exit_code=exit_code, stdout=buf.getvalue())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,4 @@
-from typer.testing import CliRunner
-
-from sorter import app
+from tests.conftest import run_cli
 from sorter.config import Settings
 
 
@@ -18,9 +16,7 @@ def test_dupes_command(tmp_path, monkeypatch):
         "sorter.cli.find_duplicates",
         lambda files, *, algorithm="sha256": {"deadbeef": [a, b]},
     )
-
-    runner = CliRunner()
-    result = runner.invoke(app, ["dupes", str(tmp_path)])
+    result = run_cli(["dupes", str(tmp_path)])
     assert result.exit_code == 0
     assert "deadbeef"[:8] in result.stdout
 
@@ -37,9 +33,7 @@ def test_dupes_algorithm_option(tmp_path, monkeypatch):
 
     monkeypatch.setattr("sorter.cli.scan_paths", fake_scan)
     monkeypatch.setattr("sorter.cli.find_duplicates", fake_find)
-
-    runner = CliRunner()
-    result = runner.invoke(app, ["dupes", str(tmp_path), "--algorithm", "md5"])
+    result = run_cli(["dupes", str(tmp_path), "--algorithm", "md5"])
     assert result.exit_code == 0
     assert calls["alg"] == "md5"
 
@@ -55,13 +49,8 @@ def test_schedule_command(tmp_path, monkeypatch):
 
     monkeypatch.setattr("sorter.scheduler.validate_cron", fake_validate)
     monkeypatch.setattr("sorter.scheduler.install_job", fake_install)
-
-    runner = CliRunner()
     dest = tmp_path / "dest"
-    result = runner.invoke(
-        app,
-        ["schedule", str(tmp_path), "--dest", str(dest), "--cron", "5 4 * * *"],
-    )
+    result = run_cli(["schedule", str(tmp_path), "--dest", str(dest), "--cron", "5 4 * * *"])
     assert result.exit_code == 0
     assert calls["validate"] == "5 4 * * *"
     assert calls["install"] == ("5 4 * * *", [tmp_path], dest)
@@ -78,17 +67,14 @@ def test_stats_command(tmp_path, monkeypatch):
         return dest
 
     monkeypatch.setattr("sorter.stats.build_dashboard", fake_dash)
-
-    runner = CliRunner()
-    result = runner.invoke(app, ["stats", str(tmp_path), "--out", str(dest)])
+    result = run_cli(["stats", str(tmp_path), "--out", str(dest)])
     assert result.exit_code == 0
     assert calls["dash"] == ([log], dest)
 
 
 def test_scan_smoke(tmp_path):
     (tmp_path / "a.txt").write_text("x")
-    runner = CliRunner()
-    result = runner.invoke(app, ["scan", str(tmp_path)])
+    result = run_cli(["scan", str(tmp_path)])
     assert result.exit_code == 0
     assert "1" in result.stdout
 
@@ -99,8 +85,7 @@ def test_move_dry_run(tmp_path, monkeypatch):
         "sorter.cli.build_report", lambda *a, **k: tmp_path / "rep.xlsx"
     )
     dest = tmp_path / "dest"
-    runner = CliRunner()
-    result = runner.invoke(app, ["move", str(tmp_path), "--dest", str(dest)])
+    result = run_cli(["move", str(tmp_path), "--dest", str(dest)])
     assert result.exit_code == 0
     assert "Dry-run" in result.stdout
 
@@ -119,17 +104,20 @@ def test_move_custom_pattern(tmp_path, monkeypatch):
 
     monkeypatch.setattr("sorter.planner.generate_name", fake_gen)
     dest = tmp_path / "dest"
-    runner = CliRunner()
-    result = runner.invoke(
-        app, ["move", str(tmp_path), "--dest", str(dest), "--pattern", "{stem}{ext}"]
-    )
+    result = run_cli([
+        "move",
+        str(tmp_path),
+        "--dest",
+        str(dest),
+        "--pattern",
+        "{stem}{ext}",
+    ])
     assert result.exit_code == 0
     assert captured["pattern"] == "{stem}{ext}"
 
 
 def test_stats_no_logs(tmp_path):
-    runner = CliRunner()
-    result = runner.invoke(app, ["stats", str(tmp_path)])
+    result = run_cli(["stats", str(tmp_path)])
     assert result.exit_code == 1
     assert "No log files found." in result.stdout
 
@@ -158,19 +146,14 @@ def test_move_destination_exists(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "sorter.cli.build_report", lambda *a, **k: tmp_path / "rep.xlsx"
     )
-
-    runner = CliRunner()
-    result = runner.invoke(
-        app,
-        [
-            "move",
-            str(tmp_path),
-            "--dest",
-            str(dest_root),
-            "--no-dry-run",
-            "--yes",
-        ],
-    )
+    result = run_cli([
+        "move",
+        str(tmp_path),
+        "--dest",
+        str(dest_root),
+        "--no-dry-run",
+        "--yes",
+    ])
     assert result.exit_code == 1
     assert "destination already exists" in result.stdout
 
@@ -192,44 +175,36 @@ def test_report_format_option(tmp_path, monkeypatch):
         return tmp_path / f"rep.{fmt}"
 
     monkeypatch.setattr("sorter.cli.build_report", fake_build_report)
-
-    runner = CliRunner()
-    result = runner.invoke(app, ["report", str(tmp_path), "--format", "json"])
+    result = run_cli(["report", str(tmp_path), "--format", "json"])
     assert result.exit_code == 0
     assert captured["fmt"] == "json"
 
 
 def test_version_option():
-    runner = CliRunner()
-    result = runner.invoke(app, ["--version"])
+    result = run_cli(["--version"])
     assert result.exit_code == 0
     assert "1.0.0" in result.stdout
 
 
 def test_scan_invalid_directory():
-    runner = CliRunner()
-    result = runner.invoke(app, ["scan", "/nonexistent"])
+    result = run_cli(["scan", "/nonexistent"])
     assert result.exit_code != 0
-    assert "does not exist" in (result.stderr or result.output)
+    assert "does not exist" in result.stdout
 
 
 def test_move_invalid_pattern(tmp_path):
     (tmp_path / "file.txt").write_text("x")
     dest = tmp_path / "dest"
-    runner = CliRunner()
-    result = runner.invoke(
-        app,
-        [
-            "move",
-            str(tmp_path),
-            "--dest",
-            str(dest),
-            "--pattern",
-            "{foo}",
-            "--no-dry-run",
-            "--yes",
-        ],
-    )
+    result = run_cli([
+        "move",
+        str(tmp_path),
+        "--dest",
+        str(dest),
+        "--pattern",
+        "{foo}",
+        "--no-dry-run",
+        "--yes",
+    ])
     assert result.exit_code != 0
 
 
@@ -238,8 +213,7 @@ def test_scan_permission_denied(monkeypatch, tmp_path):
         "sorter.cli.scan_paths",
         lambda dirs: (_ for _ in ()).throw(PermissionError("denied")),
     )
-    runner = CliRunner()
-    result = runner.invoke(app, ["scan", str(tmp_path)])
+    result = run_cli(["scan", str(tmp_path)])
     assert result.exit_code == 1
 
 
@@ -259,16 +233,12 @@ def test_move_permission_denied(monkeypatch, tmp_path):
         "sorter.cli.move_with_log",
         lambda *a, **k: (_ for _ in ()).throw(PermissionError("denied")),
     )
-    runner = CliRunner()
-    result = runner.invoke(
-        app,
-        [
-            "move",
-            str(tmp_path),
-            "--dest",
-            str(dest),
-            "--no-dry-run",
-            "--yes",
-        ],
-    )
+    result = run_cli([
+        "move",
+        str(tmp_path),
+        "--dest",
+        str(dest),
+        "--no-dry-run",
+        "--yes",
+    ])
     assert result.exit_code == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,8 @@
 import pathlib
-from typer.testing import CliRunner
 import os
 import datetime as _dt
 
-from sorter import app
+from tests.conftest import run_cli
 
 
 # Helper function to create dummy files
@@ -19,15 +18,11 @@ def create_dummy_file(path: pathlib.Path, content: str = "dummy content"):
 
 def test_move_command_dry_run(tmp_path):
     """Tests the 'move' command with --dry-run to ensure no files are actually moved."""
-    runner = CliRunner()
     source_dir = tmp_path / "source"
     dest_dir = tmp_path / "destination"
     create_dummy_file(source_dir / "test_file.txt")
 
-    result = runner.invoke(
-        app,
-        ["move", str(source_dir), "--dest", str(dest_dir), "--dry-run"],
-    )
+    result = run_cli(["move", str(source_dir), "--dest", str(dest_dir), "--dry-run"])
 
     assert result.exit_code == 0
     assert "Dry-run complete" in result.stdout
@@ -38,16 +33,19 @@ def test_move_command_dry_run(tmp_path):
 def test_move_command_with_classification(tmp_path):
     """Tests the 'move' command to ensure files are classified and moved to
     the correct subdirectories."""
-    runner = CliRunner()
     source_dir = tmp_path / "source"
     dest_dir = tmp_path / "destination"
     create_dummy_file(source_dir / "image.jpg")
     create_dummy_file(source_dir / "document.pdf")
 
-    result = runner.invoke(
-        app,
-        ["move", str(source_dir), "--dest", str(dest_dir), "--no-dry-run", "--yes"],
-    )
+    result = run_cli([
+        "move",
+        str(source_dir),
+        "--dest",
+        str(dest_dir),
+        "--no-dry-run",
+        "--yes",
+    ])
 
     assert result.exit_code == 0
     assert not (source_dir / "image.jpg").exists()
@@ -62,13 +60,12 @@ def test_move_command_with_classification(tmp_path):
 
 def test_dupes_command(tmp_path):
     """Tests the 'dupes' command to ensure it correctly identifies duplicate files."""
-    runner = CliRunner()
     source_dir = tmp_path / "source"
     create_dummy_file(source_dir / "file1.txt", "same content")
     create_dummy_file(source_dir / "file2.txt", "same content")
     create_dummy_file(source_dir / "file3.txt", "different content")
 
-    result = runner.invoke(app, ["dupes", str(source_dir)])
+    result = run_cli(["dupes", str(source_dir)])
 
     assert result.exit_code == 0
     assert "Found group with hash" in result.stdout
@@ -79,12 +76,11 @@ def test_dupes_command(tmp_path):
 
 def test_report_command(tmp_path):
     """Tests the 'report' command to ensure it generates a report of proposed moves."""
-    runner = CliRunner()
     source_dir = tmp_path / "source"
     dest_dir = tmp_path / "destination"
     create_dummy_file(source_dir / "report_file.txt")
 
-    result = runner.invoke(app, ["report", str(source_dir), "--dest", str(dest_dir)])
+    result = run_cli(["report", str(source_dir), "--dest", str(dest_dir)])
 
     assert result.exit_code == 0
     assert "Report ready" in result.stdout
@@ -95,7 +91,6 @@ def test_report_command(tmp_path):
 
 def test_undo_command(tmp_path):
     """Tests the 'undo' command to ensure it can roll back a move operation."""
-    runner = CliRunner()
     source_dir = tmp_path / "source"
     dest_dir = tmp_path / "destination"
     test_file = source_dir / "undo_test.txt"
@@ -106,17 +101,21 @@ def test_undo_command(tmp_path):
         lf.unlink()
 
     # First, move the file
-    result_move = runner.invoke(
-        app,
-        ["move", str(source_dir), "--dest", str(dest_dir), "--no-dry-run", "--yes"],
-    )
+    result_move = run_cli([
+        "move",
+        str(source_dir),
+        "--dest",
+        str(dest_dir),
+        "--no-dry-run",
+        "--yes",
+    ])
     assert result_move.exit_code == 0
 
     # Find the log file
     log_file = next(pathlib.Path.cwd().glob("file-sort-log_*.jsonl"))
 
     # Now, undo the move
-    result_undo = runner.invoke(app, ["undo", str(log_file)])
+    result_undo = run_cli(["undo", str(log_file)])
     assert result_undo.exit_code == 0
     assert "Rollback complete" in result_undo.stdout
     assert test_file.exists()
@@ -127,17 +126,20 @@ def test_undo_command(tmp_path):
 
 def test_move_with_custom_pattern(tmp_path):
     """Tests the 'move' command with a custom naming pattern."""
-    runner = CliRunner()
     source_dir = tmp_path / "source"
     dest_dir = tmp_path / "destination"
     create_dummy_file(source_dir / "pattern_test.txt")
 
     pattern = "{stem}_{date}{ext}"
-    result = runner.invoke(app, [
-        "move", str(source_dir),
-        "--dest", str(dest_dir),
-        "--pattern", pattern,
-        "--no-dry-run", "--yes"
+    result = run_cli([
+        "move",
+        str(source_dir),
+        "--dest",
+        str(dest_dir),
+        "--pattern",
+        pattern,
+        "--no-dry-run",
+        "--yes",
     ])
 
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- replace typer CLI with argparse-based implementation
- export `get_parser` and `main`
- update error handling decorator
- adjust packaging entry point
- update tests to use new CLI helpers

## Testing
- `pip install rich`
- `pip install pydantic`
- `pip install pandas joblib croniter openpyxl`
- `pip install scikit-learn`
- `pip install exifread mutagen matplotlib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a2ec81b08322bda29a8f457488b9