### PR TITLE
Refactor plugin discovery via entry points

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,12 +43,12 @@ extensions = [".epub", ".mobi"]
 [classification.Packages]
 extensions = [".deb", ".rpm", ".pkg"]
 
-[plugins.exif_renamer]
+[plugins.exif]
 enabled = true
 # Available tokens: {year}, {month}, {day}, {hour}, {minute}, {second}, {model}, {make}
 pattern = "{year}-{month}-{day}_{hour}.{minute}.{second}_{model}"
 
-[plugins.id3_renamer]
+[plugins.id3]
 enabled = true
 # Available tokens: {artist}, {album}, {title}, {track_number}, {genre}
 pattern = "{artist} - {album} - {track_number:02d} - {title}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,7 @@ ignore_missing_imports = true
 [tool.poetry.scripts]
 file-sorter-gui = "sorter_gui.app:main"
 file-sorter = "sorter.cli:main"
+
+[project.entry-points."file_flow.renamers"]
+exif = "sorter.plugins.exif_renamer:ExifRenamer"
+id3 = "sorter.plugins.id3_renamer:Id3Renamer"

--- a/sorter/plugins/base.py
+++ b/sorter/plugins/base.py
@@ -1,15 +1,24 @@
-import pathlib
-from typing import Dict, Any, Optional
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 
-class RenamerPlugin:
-    """Base class for all renamer plugins."""
+class RenamerPlugin(ABC):
+    """Abstract base class for all renamer plugins."""
 
-    def __init__(self, config: Dict[str, Any]):
-        self.config = config
-        self.enabled = config.get("enabled", False)
-        self.pattern = config.get("pattern", "")
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = config or {}
+        self.enabled = self.config.get("enabled", False)
+        self.pattern = self.config.get("pattern", "")
 
-    def rename(self, source_path: pathlib.Path) -> Optional[str]:
-        """Return a sanitized filename stem or ``None`` if plugin does not apply."""
-        raise NotImplementedError
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """A unique name for the plugin."""
+
+    @abstractmethod
+    def rename(self, file_path: Path) -> Optional[str]:
+        """Analyze ``file_path`` and return a new filename or ``None``."""
+

--- a/sorter/plugins/exif_renamer.py
+++ b/sorter/plugins/exif_renamer.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import pathlib
 import re
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 import exifread
 
@@ -8,8 +10,15 @@ from .base import RenamerPlugin
 from ..utils import sanitize_filename
 
 
-class Plugin(RenamerPlugin):
-    """A renamer plugin for photos based on EXIF data."""
+class ExifRenamer(RenamerPlugin):
+    """Rename photos based on EXIF metadata."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        super().__init__(config)
+
+    @property
+    def name(self) -> str:  # pragma: no cover - simple property
+        return "exif"
 
     def rename(self, source_path: pathlib.Path) -> Optional[str]:
         # This plugin only handles common image file types

--- a/sorter/plugins/id3_renamer.py
+++ b/sorter/plugins/id3_renamer.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import pathlib
 import logging
-from typing import Optional, Any
+from typing import Any, Optional
 
 from mutagen.easyid3 import EasyID3
 from mutagen.flac import FLAC
@@ -10,8 +12,15 @@ from .base import RenamerPlugin
 from ..utils import sanitize_filename
 
 
-class Plugin(RenamerPlugin):
-    """A renamer plugin for audio files based on ID3, MP4, or FLAC tags."""
+class Id3Renamer(RenamerPlugin):
+    """Rename audio files using ID3/FLAC/MP4 tags."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config)
+
+    @property
+    def name(self) -> str:  # pragma: no cover - simple property
+        return "id3"
 
     def rename(self, source_path: pathlib.Path) -> Optional[str]:
         suffix = source_path.suffix.lower()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,6 +1,7 @@
 import pathlib
 import sys
 import types
+import importlib.metadata
 
 from sorter.plugin_manager import PluginManager
 from sorter.plugins.base import RenamerPlugin
@@ -12,60 +13,83 @@ def test_plugin_loading_and_rename(monkeypatch):
 
     module = types.ModuleType("sorter.plugins.temp_plugin")
 
-    class Plugin(RenamerPlugin):
+    class TempPlugin(RenamerPlugin):
+        @property
+        def name(self) -> str:
+            return "temp"
+
         def rename(self, source_path: pathlib.Path):
             calls.append(source_path)
             return unique_stem
 
-    module.Plugin = Plugin
+    module.TempPlugin = TempPlugin
     monkeypatch.setitem(sys.modules, "sorter.plugins.temp_plugin", module)
 
-    def fake_iter_modules(_path):
-        yield None, "temp_plugin", False
+    ep = importlib.metadata.EntryPoint(
+        name="temp",
+        value="sorter.plugins.temp_plugin:TempPlugin",
+        group="file_flow.renamers",
+    )
 
-    monkeypatch.setattr("sorter.plugin_manager.pkgutil.iter_modules", fake_iter_modules)
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda group=None: [ep] if group == "file_flow.renamers" else [],
+    )
 
-    manager = PluginManager({"plugins": {"temp_plugin": {"enabled": True}}})
+    manager = PluginManager({"plugins": {"temp": {"enabled": True}}})
     assert len(manager.renamer_plugins) == 1
-    assert isinstance(manager.renamer_plugins[0], Plugin)
+    assert isinstance(manager.renamer_plugins[0], TempPlugin)
 
     result = manager.rename_with_plugin(pathlib.Path("file.txt"))
     assert result == unique_stem
     assert len(calls) == 1
 
-    disabled = PluginManager({"plugins": {"temp_plugin": {"enabled": False}}})
+    disabled = PluginManager({"plugins": {"temp": {"enabled": False}}})
     assert disabled.renamer_plugins == []
 
 
 def test_real_plugins_loading(monkeypatch):
     cfg = {
         "plugins": {
-            "exif_renamer": {"enabled": True},
-            "id3_renamer": {"enabled": True},
+            "exif": {"enabled": True},
+            "id3": {"enabled": True},
         }
     }
     monkeypatch.setattr(
-        "sorter.plugins.exif_renamer.Plugin.rename",
-        lambda self, p: "exif",
+        "sorter.plugins.exif_renamer.ExifRenamer.rename", lambda self, p: "exif"
     )
     monkeypatch.setattr(
-        "sorter.plugins.id3_renamer.Plugin.rename",
-        lambda self, p: "id3",
+        "sorter.plugins.id3_renamer.Id3Renamer.rename", lambda self, p: "id3"
     )
+
+    ep1 = importlib.metadata.EntryPoint(
+        name="exif",
+        value="sorter.plugins.exif_renamer:ExifRenamer",
+        group="file_flow.renamers",
+    )
+    ep2 = importlib.metadata.EntryPoint(
+        name="id3",
+        value="sorter.plugins.id3_renamer:Id3Renamer",
+        group="file_flow.renamers",
+    )
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda group=None: [ep1, ep2] if group == "file_flow.renamers" else [],
+    )
+
     manager = PluginManager(cfg)
-    modules = [
-        p.__class__.__module__.split(".")[-1]
-        for p in manager.renamer_plugins
-    ]
-    assert modules == ["exif_renamer", "id3_renamer"]
+    modules = [p.name for p in manager.renamer_plugins]
+    assert modules == ["exif", "id3"]
     assert manager.rename_with_plugin(pathlib.Path("file.jpg")) == "exif"
 
 
 def test_multiple_plugins_order(monkeypatch):
     cfg = {
         "plugins": {
-            "exif_renamer": {"enabled": True},
-            "id3_renamer": {"enabled": True},
+            "exif": {"enabled": True},
+            "id3": {"enabled": True},
         }
     }
     calls = []
@@ -78,8 +102,25 @@ def test_multiple_plugins_order(monkeypatch):
         calls.append("id3")
         return "done"
 
-    monkeypatch.setattr("sorter.plugins.exif_renamer.Plugin.rename", exif_rename)
-    monkeypatch.setattr("sorter.plugins.id3_renamer.Plugin.rename", id3_rename)
+    monkeypatch.setattr("sorter.plugins.exif_renamer.ExifRenamer.rename", exif_rename)
+    monkeypatch.setattr("sorter.plugins.id3_renamer.Id3Renamer.rename", id3_rename)
+
+    ep1 = importlib.metadata.EntryPoint(
+        name="exif",
+        value="sorter.plugins.exif_renamer:ExifRenamer",
+        group="file_flow.renamers",
+    )
+    ep2 = importlib.metadata.EntryPoint(
+        name="id3",
+        value="sorter.plugins.id3_renamer:Id3Renamer",
+        group="file_flow.renamers",
+    )
+    monkeypatch.setattr(
+        importlib.metadata,
+        "entry_points",
+        lambda group=None: [ep1, ep2] if group == "file_flow.renamers" else [],
+    )
+
     manager = PluginManager(cfg)
     manager.rename_with_plugin(pathlib.Path("song.mp3"))
     assert calls == ["exif", "id3"]


### PR DESCRIPTION
## Summary
- define `RenamerPlugin` as an abstract base class
- register `ExifRenamer` and `Id3Renamer` plugins
- load plugins via `importlib.metadata` entry points
- update sample configuration and plugin tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c28cb0f083229f2907ac9000414b