### PR TITLE
Add docstring style guide and pydocstyle check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,14 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        args:
+          - --convention=google
+          - --add-ignore=D100,D101,D102,D103,D104,D107
+        files: ^sorter/
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.16.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Thank you for considering contributing to File-Flow.
+
+## Development setup
+
+Install the development dependencies and set up the git hooks:
+
+```bash
+pip install -r requirements.txt  # or `poetry install`
+pre-commit install
+```
+
+## Docstring style
+
+This project uses the **Google Python Style** for all docstrings. Each public
+module, class and function should include a clear docstring describing its
+purpose, arguments, return values and possible exceptions. The formatting is
+checked automatically using `pydocstyle` via pre-commit hooks.

--- a/sorter/planner.py
+++ b/sorter/planner.py
@@ -16,12 +16,25 @@ def plan_moves(
     *,
     pattern: str | None = None,
 ) -> list[tuple[pathlib.Path, pathlib.Path]]:
-    """Return mapping of source files to destination paths.
+    """Generate destination paths for all files found in ``dirs``.
 
-    This performs scanning, classification and plugin-based renaming so that
-    both the CLI and GUI can share identical logic.
+    The function scans the provided directories, classifies each file and
+    optionally renames it using installed plugins. The resulting mapping can be
+    used by both the CLI and GUI interfaces to carry out move operations.
+
+    Args:
+        dirs: A sequence of directories to scan for files.
+        dest: The root directory where files will be moved.
+        pattern: Optional naming pattern overriding the default renamer
+            behaviour.
+
+    Returns:
+        A list of ``(source, destination)`` path tuples representing where each
+        file should be moved.
+
+    Raises:
+        ValueError: If ``dest`` does not represent a valid directory.
     """
-
     config = load_config()
     plugin_manager = PluginManager(config)
     files = scan_paths(list(dirs))


### PR DESCRIPTION
## Summary
- document docstring style guidelines
- use Google style pydocstyle in pre-commit
- expand the `plan_moves` docstring with Google-style sections

## Testing
- `pre-commit run --files sorter/planner.py .pre-commit-config.yaml CONTRIBUTING.md` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865d7adfc3083228e78f37bc6149998