### PR TITLE
Add threaded progress updates to GUI

### DIFF
--- a/sorter_gui/app.py
+++ b/sorter_gui/app.py
@@ -166,7 +166,13 @@ class MainWindow(QMainWindow):  # type: ignore[misc]
             except Exception as exc:
                 self.task_queue.put(("error", str(exc)))
 
-        def done(result: tuple[list[tuple[pathlib.Path, pathlib.Path]], pathlib.Path, bool]) -> None:
+        def done(
+            result: tuple[
+                list[tuple[pathlib.Path, pathlib.Path]],
+                pathlib.Path,
+                bool,
+            ]
+        ) -> None:
             mapping, report, dry_flag = result
             self._mapping = mapping
             self.btn_move.setEnabled(not dry_flag)

--- a/sorter_gui/app.py
+++ b/sorter_gui/app.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import pathlib
 import sys
+import threading
+import queue
+
 from typing import Any, Iterable
 
-from PyQt6.QtCore import QRunnable, QThreadPool, pyqtSignal, QObject
+from PyQt6.QtCore import QTimer
 from PyQt6.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -20,32 +23,11 @@ from PyQt6.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
     QWidget,
+    QProgressBar,
 )
 
 from sorter import build_report, move_with_log, plan_moves
 from sorter.rollback import rollback
-
-
-class WorkerSignals(QObject):  # type: ignore[misc]
-    finished = pyqtSignal(object)
-    error = pyqtSignal(str)
-
-
-class Worker(QRunnable):  # type: ignore[misc]
-    def __init__(self, fn: Any, *args: Any, **kwargs: Any) -> None:
-        super().__init__()
-        self.fn = fn
-        self.args = args
-        self.kwargs = kwargs
-        self.signals = WorkerSignals()
-
-    def run(self) -> None:  # noqa: D401 - Qt callback
-        try:
-            result = self.fn(*self.args, **self.kwargs)
-        except Exception as exc:  # pragma: no cover - GUI feedback only
-            self.signals.error.emit(str(exc))
-        else:
-            self.signals.finished.emit(result)
 
 
 def _build_mapping(
@@ -60,7 +42,11 @@ class MainWindow(QMainWindow):  # type: ignore[misc]
         self.setWindowTitle("File Sorter")
         self._mapping: list[tuple[pathlib.Path, pathlib.Path]] = []
         self._last_log: pathlib.Path | None = None
-        self.pool = QThreadPool.globalInstance()
+        self.task_queue: queue.Queue = queue.Queue()
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self._check_queue)
+        self._worker_thread: threading.Thread | None = None
+        self._done_callback: Any | None = None
         self._build_ui()
 
     # ---------------- UI setup -----------------
@@ -100,6 +86,10 @@ class MainWindow(QMainWindow):  # type: ignore[misc]
         h_btn.addWidget(self.btn_move)
         vbox.addLayout(h_btn)
 
+        self.progress = QProgressBar()
+        self.progress.setMaximum(100)
+        vbox.addWidget(self.progress)
+
         self.log = QTextEdit()
         self.log.setReadOnly(True)
         vbox.addWidget(QLabel("Log:"))
@@ -109,13 +99,40 @@ class MainWindow(QMainWindow):  # type: ignore[misc]
 
     # -------------- helper methods --------------
     def _log(self, text: str) -> None:
+        """Append *text* to the log widget."""
         self.log.append(text)
 
-    def _run_thread(self, fn: Any, callback: Any) -> None:
-        worker = Worker(fn)
-        worker.signals.finished.connect(callback)
-        worker.signals.error.connect(lambda e: self._log(f"Error: {e}"))
-        self.pool.start(worker)
+    def _start_thread(self, fn: Any, callback: Any) -> None:
+        """Run *fn* in a background thread and call *callback* when done."""
+        self._done_callback = callback
+        self._worker_thread = threading.Thread(target=fn, daemon=True)
+        self._worker_thread.start()
+        self.timer.start(100)
+
+    def _check_queue(self) -> None:
+        """Process messages from the worker thread."""
+        try:
+            msg_type, data = self.task_queue.get_nowait()
+        except queue.Empty:
+            if self._worker_thread and not self._worker_thread.is_alive():
+                self.timer.stop()
+            return
+
+        if msg_type == "progress":
+            self.progress.setValue(int(data))
+        elif msg_type == "done":
+            self.timer.stop()
+            self.progress.setValue(0)
+            if self._done_callback:
+                self._done_callback(data)
+            self._worker_thread = None
+        elif msg_type == "error":
+            self.timer.stop()
+            self.progress.setValue(0)
+            self._log(f"Error: {data}")
+            self.btn_report.setEnabled(True)
+            self.btn_move.setEnabled(True)
+            self._worker_thread = None
 
     def _add_folder(self) -> None:
         path = QFileDialog.getExistingDirectory(self, "Select Folder")
@@ -141,19 +158,24 @@ class MainWindow(QMainWindow):  # type: ignore[misc]
             return
         dry = self.dry_run.isChecked()
 
-        def work() -> tuple[list[tuple[pathlib.Path, pathlib.Path]], pathlib.Path]:
-            mapping = _build_mapping(paths, dest)
-            report = build_report(mapping, auto_open=True)
-            return mapping, report
+        def work() -> None:
+            try:
+                mapping = _build_mapping(paths, dest)
+                report = build_report(mapping, auto_open=True)
+                self.task_queue.put(("done", (mapping, report, dry)))
+            except Exception as exc:
+                self.task_queue.put(("error", str(exc)))
 
-        def done(
-            result: tuple[list[tuple[pathlib.Path, pathlib.Path]], pathlib.Path],
-        ) -> None:
-            self._mapping, report = result
-            self.btn_move.setEnabled(not dry)
+        def done(result: tuple[list[tuple[pathlib.Path, pathlib.Path]], pathlib.Path, bool]) -> None:
+            mapping, report, dry_flag = result
+            self._mapping = mapping
+            self.btn_move.setEnabled(not dry_flag)
             self._log(f"Report saved to {report}")
+            self.btn_report.setEnabled(True)
 
-        self._run_thread(work, done)
+        self.btn_report.setEnabled(False)
+        self.btn_move.setEnabled(False)
+        self._start_thread(work, done)
 
     def _on_move(self) -> None:
         if not self._mapping:
@@ -169,8 +191,13 @@ class MainWindow(QMainWindow):  # type: ignore[misc]
         ):
             return
 
-        def work() -> pathlib.Path:
-            return move_with_log(self._mapping, show_progress=False)
+        def work() -> None:
+            try:
+                log_path = move_with_log(self._mapping, show_progress=False)
+                self.task_queue.put(("progress", 100))
+                self.task_queue.put(("done", log_path))
+            except Exception as exc:
+                self.task_queue.put(("error", str(exc)))
 
         def done(log_path: pathlib.Path) -> None:
             self._last_log = log_path
@@ -184,8 +211,12 @@ class MainWindow(QMainWindow):  # type: ignore[misc]
             if mb.clickedButton() == undo_btn:
                 rollback(log_path)
                 self._log("Rollback complete")
+            self.btn_report.setEnabled(True)
+            self.btn_move.setEnabled(True)
 
-        self._run_thread(work, done)
+        self.btn_move.setEnabled(False)
+        self.btn_report.setEnabled(False)
+        self._start_thread(work, done)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add `queue.Queue` and `threading.Thread` to run report and move actions
- poll background work with `QTimer` and update a `QProgressBar`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865da0feb688322b42b4d74a90ec462