### PR TITLE
Add progress updates to GUI

### DIFF
--- a/sorter_gui/app.py
+++ b/sorter_gui/app.py
@@ -191,7 +191,9 @@ class MainWindow(QMainWindow):  # type: ignore[misc]
             progress_cb(100, None)
             return mapping, report, dry
 
-        def done(result: tuple[list[tuple[pathlib.Path, pathlib.Path]], pathlib.Path, bool]) -> None:
+        def done(
+            result: tuple[list[tuple[pathlib.Path, pathlib.Path]], pathlib.Path, bool]
+        ) -> None:
             mapping, report, dry_flag = result
             self._mapping = mapping
             self.btn_move.setEnabled(not dry_flag)


### PR DESCRIPTION
## Summary
- emit progress from `move_with_log`
- refactor GUI threading with `Worker` and Qt signals
- show progress and popup errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6865fd42f2108322868848a82d7e5a0f