### PR TITLE
Add minimal config example

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -8,6 +8,21 @@ pip install file-flow
 ## Configuration
 File-Sorter reads settings from `config.toml` and validates them using
 Pydantic. Copy the example file and modify as needed.
+Default rules for common extensions are loaded from `data/default_rules.toml`.
+
+Here is a minimal configuration showing how to add custom categories and enable
+plugins:
+
+```toml
+fallback_category = "Other"
+
+[classification.Pictures]
+extensions = [".jpg", ".png"]
+
+[plugins.exif]
+enabled = true
+pattern = "{year}-{month}-{day}_{model}"
+```
 
 ## Example Usage
 ```bash


### PR DESCRIPTION
## Summary
- document a minimal `config.toml`
- clarify that default rules are loaded from `data/default_rules.toml`

## Testing
- `pre-commit run --files docs/user_guide.md`

------
https://chatgpt.com/codex/tasks/task_e_686607b0f4d8832296c5d057790d5d5a