### PR TITLE
Refactor classify_file with RuleMatcher

### DIFF
--- a/sorter/classifier.py
+++ b/sorter/classifier.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional, Union
 
 from pydantic import BaseModel
 
-import json
 import logging
 import magic  # python-magic
 
@@ -18,7 +17,7 @@ try:
     from . import clustering  # type: ignore
 except ImportError:  # pragma: no cover - optional dep missing
     clustering = None  # type: ignore
-from .config import load_config, Settings
+from .config import Settings
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_classify_file.py
+++ b/tests/test_classify_file.py
@@ -1,6 +1,5 @@
 import magic
 from sorter.classifier import classify_file
-from pathlib import Path
 
 
 def test_extension_rule(tmp_path):

--- a/tests/test_classify_file.py
+++ b/tests/test_classify_file.py
@@ -1,84 +1,18 @@
-import json
+import magic
 from sorter.classifier import classify_file
-from sorter.config import Settings
+from pathlib import Path
 
 
-def test_supervised_prediction(tmp_path, monkeypatch):
-    f = tmp_path / "file.txt"
-    f.write_text("x")
-
-    monkeypatch.setattr("sorter.supervised.predict_category", lambda p: "Docs")
-    monkeypatch.setattr("sorter.classifier.load_config", lambda: Settings())
-
-    assert classify_file(f) == "Docs"
+def test_extension_rule(tmp_path):
+    f = tmp_path / "foo.xyz"
+    f.write_text("data")
+    rules = {"Dest": {"extensions": [".xyz"]}}
+    assert classify_file(f, rules) == "Dest"
 
 
-def test_rule_based(tmp_path, monkeypatch):
-    f = tmp_path / "picture.jpg"
+def test_mimetype_rule(tmp_path, monkeypatch):
+    f = tmp_path / "bar.bin"
     f.write_bytes(b"x")
-
-    monkeypatch.setattr("sorter.supervised.predict_category", lambda p: None)
-    monkeypatch.setattr(
-        "sorter.classifier.load_config",
-        lambda: Settings(
-            classification={"Pictures": {"extensions": [".jpg"]}}
-        ),
-    )
-
-    assert classify_file(f) == "Pictures"
-
-
-def test_cluster_label(tmp_path, monkeypatch):
-    f = tmp_path / "unknown.bin"
-    f.write_bytes(b"x")
-
-    model_path = tmp_path / "model.joblib"
-    model_path.touch()
-    labels_path = tmp_path / "labels.json"
-    labels_path.write_text(json.dumps({"1": "Music"}))
-
-    monkeypatch.setattr("sorter.supervised.predict_category", lambda p: None)
-    monkeypatch.setattr(
-        "sorter.classifier.load_config", lambda: Settings(fallback_category=None)
-    )
-    monkeypatch.setattr("sorter.classifier.classify", lambda p, c: None)
-    monkeypatch.setattr("sorter.clustering.MODEL_PATH", model_path)
-    monkeypatch.setattr("sorter.clustering.LABELS_PATH", labels_path)
-    monkeypatch.setattr("sorter.clustering.predict_cluster", lambda p: 1)
-
-    assert classify_file(f) == "Music"
-
-
-def test_unsorted(tmp_path, monkeypatch):
-    f = tmp_path / "mystery.dat"
-    f.write_bytes(b"x")
-
-    monkeypatch.setattr("sorter.supervised.predict_category", lambda p: None)
-    monkeypatch.setattr(
-        "sorter.classifier.load_config", lambda: Settings(fallback_category=None)
-    )
-    monkeypatch.setattr("sorter.classifier.classify", lambda p, c: None)
-    monkeypatch.setattr("sorter.clustering.MODEL_PATH", tmp_path / "no_model")
-    monkeypatch.setattr("sorter.clustering.LABELS_PATH", tmp_path / "no_labels")
-    monkeypatch.setattr("sorter.clustering.predict_cluster", lambda p: None)
-
-    assert classify_file(f) == "Unsorted"
-
-
-def test_custom_config_rules(tmp_path, monkeypatch):
-    f = tmp_path / "data.xyz"
-    f.write_text("x")
-    cfg = Settings(classification={"XYZ": {"extensions": [".xyz"]}})
-    monkeypatch.setattr("sorter.classifier.load_config", lambda: cfg)
-    monkeypatch.setattr("sorter.supervised.predict_category", lambda p: None)
-    assert classify_file(f) == "XYZ"
-
-
-def test_mime_type_classification(monkeypatch, tmp_path):
-    f = tmp_path / "foo.bin"
-    f.write_bytes(b"x")
-    monkeypatch.setattr("magic.from_file", lambda *a, **k: "audio/flac")
-    cfg = Settings(classification={"Audio": {"mimetypes": ["audio/flac"]}})
-    monkeypatch.setattr("sorter.classifier.load_config", lambda: cfg)
-    monkeypatch.setattr("sorter.supervised.predict_category", lambda p: None)
-    assert classify_file(f) == "Audio"
+    monkeypatch.setattr(magic, "from_file", lambda *a, **k: "audio/flac")
+    rules = {"Music": {"mimetypes": ["audio/flac"]}}
+    assert classify_file(f, rules) == "Music"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,14 +50,16 @@ def test_schedule_command(tmp_path, monkeypatch):
     monkeypatch.setattr("sorter.scheduler.validate_cron", fake_validate)
     monkeypatch.setattr("sorter.scheduler.install_job", fake_install)
     dest = tmp_path / "dest"
-    result = run_cli([
-        "schedule",
-        str(tmp_path),
-        "--dest",
-        str(dest),
-        "--cron",
-        "5 4 * * *",
-    ])
+    result = run_cli(
+        [
+            "schedule",
+            str(tmp_path),
+            "--dest",
+            str(dest),
+            "--cron",
+            "5 4 * * *",
+        ]
+    )
     assert result.exit_code == 0
     assert calls["validate"] == "5 4 * * *"
     assert calls["install"] == ("5 4 * * *", [tmp_path], dest)
@@ -111,14 +113,16 @@ def test_move_custom_pattern(tmp_path, monkeypatch):
 
     monkeypatch.setattr("sorter.planner.generate_name", fake_gen)
     dest = tmp_path / "dest"
-    result = run_cli([
-        "move",
-        str(tmp_path),
-        "--dest",
-        str(dest),
-        "--pattern",
-        "{stem}{ext}",
-    ])
+    result = run_cli(
+        [
+            "move",
+            str(tmp_path),
+            "--dest",
+            str(dest),
+            "--pattern",
+            "{stem}{ext}",
+        ]
+    )
     assert result.exit_code == 0
     assert captured["pattern"] == "{stem}{ext}"
 
@@ -148,19 +152,21 @@ def test_move_destination_exists(tmp_path, monkeypatch):
             return None
 
     monkeypatch.setattr("sorter.planner.PluginManager", PM)
-    monkeypatch.setattr("sorter.planner.classify_file", lambda p: None)
+    monkeypatch.setattr("sorter.planner.classify_file", lambda p, r: None)
     monkeypatch.setattr("sorter.planner.generate_name", lambda *a, **k: conflict)
     monkeypatch.setattr(
         "sorter.cli.build_report", lambda *a, **k: tmp_path / "rep.xlsx"
     )
-    result = run_cli([
-        "move",
-        str(tmp_path),
-        "--dest",
-        str(dest_root),
-        "--no-dry-run",
-        "--yes",
-    ])
+    result = run_cli(
+        [
+            "move",
+            str(tmp_path),
+            "--dest",
+            str(dest_root),
+            "--no-dry-run",
+            "--yes",
+        ]
+    )
     assert result.exit_code == 1
     assert "destination already exists" in result.stdout
 
@@ -170,7 +176,7 @@ def test_report_format_option(tmp_path, monkeypatch):
     src.write_text("x")
 
     monkeypatch.setattr("sorter.planner.scan_paths", lambda dirs: [src])
-    monkeypatch.setattr("sorter.planner.classify_file", lambda p: None)
+    monkeypatch.setattr("sorter.planner.classify_file", lambda p, r: None)
     monkeypatch.setattr(
         "sorter.planner.generate_name", lambda *a, **k: tmp_path / "dest" / "a.txt"
     )
@@ -202,16 +208,18 @@ def test_scan_invalid_directory():
 def test_move_invalid_pattern(tmp_path):
     (tmp_path / "file.txt").write_text("x")
     dest = tmp_path / "dest"
-    result = run_cli([
-        "move",
-        str(tmp_path),
-        "--dest",
-        str(dest),
-        "--pattern",
-        "{foo}",
-        "--no-dry-run",
-        "--yes",
-    ])
+    result = run_cli(
+        [
+            "move",
+            str(tmp_path),
+            "--dest",
+            str(dest),
+            "--pattern",
+            "{foo}",
+            "--no-dry-run",
+            "--yes",
+        ]
+    )
     assert result.exit_code != 0
 
 
@@ -240,12 +248,14 @@ def test_move_permission_denied(monkeypatch, tmp_path):
         "sorter.cli.move_with_log",
         lambda *a, **k: (_ for _ in ()).throw(PermissionError("denied")),
     )
-    result = run_cli([
-        "move",
-        str(tmp_path),
-        "--dest",
-        str(dest),
-        "--no-dry-run",
-        "--yes",
-    ])
+    result = run_cli(
+        [
+            "move",
+            str(tmp_path),
+            "--dest",
+            str(dest),
+            "--no-dry-run",
+            "--yes",
+        ]
+    )
     assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- introduce `RuleMatcher` helper for rule evaluation
- simplify `classify_file` API to accept rules directly
- adjust planner to pass rules to `classify_file`
- update tests for new behaviour

## Testing
- `black sorter/classifier.py sorter/planner.py tests/test_classify_file.py tests/test_cli.py`
- `flake8 sorter/classifier.py sorter/planner.py tests/test_classify_file.py tests/test_cli.py`
- `mypy sorter/classifier.py sorter/planner.py tests/test_classify_file.py tests/test_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68660ddfa9788322a4bd7bd61ce6442d