### PR TITLE
Add rule priority and images rename

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 fallback_category = "Other"
 
 
-[classification.Pictures]
+[classification.Images]
 extensions = [
     ".jpg",
     ".jpeg",

--- a/data/default_rules.toml
+++ b/data/default_rules.toml
@@ -1,58 +1,127 @@
-[ext]
-".pdf" = "Documents"
-".txt" = "Documents"
-".doc" = "Documents"
-".docx" = "Documents"
-".rtf" = "Documents"
-".odt" = "Documents"
-".xls" = "Spreadsheets"
-".xlsx" = "Spreadsheets"
-".ods" = "Spreadsheets"
-".csv" = "Spreadsheets"
-".ppt" = "Presentations"
-".pptx" = "Presentations"
-".odp" = "Presentations"
-".mp4" = "Videos"
-".mov" = "Videos"
-".avi" = "Videos"
-".mkv" = "Videos"
-".wmv" = "Videos"
-".flv" = "Videos"
-".mp3" = "Audio"
-".wav" = "Audio"
-".flac" = "Audio"
-".aac" = "Audio"
-".ogg" = "Audio"
-".m4a" = "Audio"
-".wma" = "Audio"
-".jpg" = "Pictures"
-".jpeg" = "Pictures"
-".png" = "Pictures"
-".gif" = "Pictures"
-".bmp" = "Pictures"
-".tiff" = "Pictures"
-".svg" = "Pictures"
-".webp" = "Pictures"
-".zip" = "Archives"
-".tar" = "Archives"
-".gz" = "Archives"
-".rar" = "Archives"
-".7z" = "Archives"
-".bz2" = "Archives"
-".xz" = "Archives"
-".py" = "Scripts"
-".js" = "Scripts"
-".sh" = "Scripts"
-".bat" = "Scripts"
-".ps1" = "Scripts"
-".pl" = "Scripts"
-".rb" = "Scripts"
-".ttf" = "Fonts"
-".otf" = "Fonts"
-".woff" = "Fonts"
-".woff2" = "Fonts"
-".epub" = "Books"
-".mobi" = "Books"
-".deb" = "Packages"
-".rpm" = "Packages"
-".pkg" = "Packages"
+[rules.Documents]
+destination = "Documents"
+priority = 10
+extensions = [
+    ".pdf",
+    ".txt",
+    ".doc",
+    ".docx",
+    ".rtf",
+    ".odt"
+]
+
+[rules.Spreadsheets]
+destination = "Spreadsheets"
+priority = 10
+extensions = [
+    ".xls",
+    ".xlsx",
+    ".ods",
+    ".csv"
+]
+
+[rules.Presentations]
+destination = "Presentations"
+priority = 10
+extensions = [
+    ".ppt",
+    ".pptx",
+    ".odp"
+]
+
+[rules.Videos]
+destination = "Videos"
+priority = 10
+extensions = [
+    ".mp4",
+    ".mov",
+    ".avi",
+    ".mkv",
+    ".wmv",
+    ".flv"
+]
+
+[rules.Audio]
+destination = "Audio"
+priority = 10
+extensions = [
+    ".mp3",
+    ".wav",
+    ".flac",
+    ".aac",
+    ".ogg",
+    ".m4a",
+    ".wma"
+]
+
+[rules.Images]
+destination = "Images"
+priority = 10
+extensions = [
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".gif",
+    ".bmp",
+    ".tiff",
+    ".svg",
+    ".webp"
+]
+
+[rules.Screenshots]
+destination = "Images/Screenshots"
+priority = 20
+condition = "filename_matches('Screenshot*') AND mime_type == 'image/png'"
+
+[rules.Archives]
+destination = "Archives"
+priority = 10
+extensions = [
+    ".zip",
+    ".tar",
+    ".gz",
+    ".rar",
+    ".7z",
+    ".bz2",
+    ".xz"
+]
+
+[rules.Scripts]
+destination = "Scripts"
+priority = 10
+extensions = [
+    ".py",
+    ".js",
+    ".sh",
+    ".bat",
+    ".ps1",
+    ".pl",
+    ".rb"
+]
+
+[rules.Fonts]
+destination = "Fonts"
+priority = 10
+extensions = [
+    ".ttf",
+    ".otf",
+    ".woff",
+    ".woff2"
+]
+
+[rules.Books]
+destination = "Books"
+priority = 10
+extensions = [
+    ".epub",
+    ".mobi"
+]
+
+[rules.Packages]
+destination = "Packages"
+priority = 10
+extensions = [
+    ".deb",
+    ".rpm",
+    ".pkg"
+]

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -16,7 +16,7 @@ plugins:
 ```toml
 fallback_category = "Other"
 
-[classification.Pictures]
+[classification.Images]
 extensions = [".jpg", ".png"]
 
 [plugins.exif]

--- a/sorter/classifier.py
+++ b/sorter/classifier.py
@@ -102,7 +102,7 @@ def _get_generic_category(path: pathlib.Path) -> Optional[str]:
         category = {
             "video": "Videos",
             "audio": "Audio",
-            "image": "Pictures",
+            "image": "Images",
             "text": "Documents",
             "application": "Documents",
         }.get(major)
@@ -116,8 +116,15 @@ def _get_generic_category(path: pathlib.Path) -> Optional[str]:
 def classify_file(file_path: pathlib.Path, rules: Dict[str, Any]) -> Optional[str]:
     """Classify ``file_path`` using a dictionary of ``rules``."""
 
-    for destination, rule_config in rules.items():
+    # Sort rules by priority, highest first. Missing priority defaults to 0.
+    sorted_rules = sorted(
+        rules.items(),
+        key=lambda item: item[1].get("priority", 0),
+        reverse=True,
+    )
+
+    for destination, rule_config in sorted_rules:
         matcher = RuleMatcher(file_path, rule_config)
         if matcher.match():
-            return destination
+            return rule_config.get("destination", destination)
     return None

--- a/sorter/config.py
+++ b/sorter/config.py
@@ -21,6 +21,9 @@ def _load_default_rules() -> dict[str, dict[str, list[str]]]:
     except OSError:
         return {}
 
+    if "rules" in raw:
+        return raw["rules"]
+
     ext_map: dict[str, str] = raw.get("ext", {})
     rules: dict[str, dict[str, list[str]]] = {}
     for ext, category in ext_map.items():
@@ -109,6 +112,9 @@ def get_rules(path: pathlib.Path | None = None) -> dict[str, dict[str, list[str]
             raw = tomllib.load(fp)
     except OSError:
         return DEFAULT_RULES
+
+    if "rules" in raw:
+        return raw["rules"]
 
     ext_map: dict[str, str] = raw.get("ext", {})
     rules: dict[str, dict[str, list[str]]] = {}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -13,7 +13,7 @@ def test_case_insensitive(tmp_path):
     f = tmp_path / "PIC.JPG"
     f.write_bytes(b"dummy")
     cfg = {"classification": DEFAULT_RULES}
-    assert classify(f, cfg) == "Pictures"
+    assert classify(f, cfg) == "Images"
 
 
 def test_magic_fallback(monkeypatch, tmp_path):

--- a/tests/test_classify_file.py
+++ b/tests/test_classify_file.py
@@ -15,3 +15,16 @@ def test_mimetype_rule(tmp_path, monkeypatch):
     monkeypatch.setattr(magic, "from_file", lambda *a, **k: "audio/flac")
     rules = {"Music": {"mimetypes": ["audio/flac"]}}
     assert classify_file(f, rules) == "Music"
+
+def test_priority_and_destination(tmp_path):
+    f = tmp_path / "Screen.png"
+    f.write_text("data")
+    rules = {
+        "Images": {"extensions": [".png"], "priority": 10},
+        "Screenshots": {
+            "extensions": [".png"],
+            "priority": 20,
+            "destination": "Images/Screenshots",
+        },
+    }
+    assert classify_file(f, rules) == "Images/Screenshots"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -52,7 +52,9 @@ def test_move_command_with_classification(tmp_path):
     assert result.exit_code == 0
     assert not (source_dir / "image.jpg").exists()
     assert not (source_dir / "document.pdf").exists()
-    assert (dest_dir / "Pictures" / f"{source_dir.name}_2025-06-30_image.jpg").exists()
+    assert (
+        dest_dir / "Images" / f"{source_dir.name}_2025-06-30_image.jpg"
+    ).exists()
     assert (
         dest_dir / "Documents" / f"{source_dir.name}_2025-06-30_document.pdf"
     ).exists()


### PR DESCRIPTION
## Summary
- update default rules to specify destinations, priorities, and example conditions
- support loading `[rules]` sections in the config helpers
- sort rules by priority in `classify_file`
- rename generic image category to `Images`
- tweak config sample and docs
- adjust tests for new behaviour and add coverage for priority

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866200ab41c832293db2205d4f77a83