### PR TITLE
Fix scheduler start boundary timestamp

### DIFF
--- a/sorter/scheduler.py
+++ b/sorter/scheduler.py
@@ -54,8 +54,7 @@ def _install_windows(cron_expr: str, cmd: str) -> None:
 
     itr = croniter(cron_expr, datetime.now())
     next_time = itr.get_next(datetime)
-    hour = next_time.hour
-    minute = next_time.minute
+    start = next_time.strftime("%Y-%m-%dT%H:%M:%S")
 
     task_xml = textwrap.dedent(
         f"""
@@ -63,7 +62,7 @@ def _install_windows(cron_expr: str, cmd: str) -> None:
               xmlns='http://schemas.microsoft.com/windows/2004/02/mit/task'>
           <Triggers>
             <CalendarTrigger>
-              <StartBoundary>2024-01-01T{hour:02d}:{minute:02d}:00</StartBoundary>
+              <StartBoundary>{start}</StartBoundary>
               <ScheduleByDay>
                 <DaysInterval>1</DaysInterval>
               </ScheduleByDay>

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -87,7 +87,12 @@ def test_install_windows(monkeypatch, tmp_path):
     assert xml_file.exists()
     content = xml_file.read_text()
     assert "<Command>cmd</Command>" in content
-    assert "<StartBoundary>2024-01-01T00:00:00</StartBoundary>" in content
+
+    from datetime import datetime
+
+    itr = scheduler.croniter("0 0 * * *", datetime.now())
+    start = itr.get_next(datetime).strftime("%Y-%m-%dT%H:%M:%S")
+    assert f"<StartBoundary>{start}</StartBoundary>" in content
     assert "/XML" in captured["args"]
     assert str(xml_file) in captured["args"]
 


### PR DESCRIPTION
## Summary
- compute start boundary timestamp using croniter
- test scheduler for dynamic start time

## Testing
- `pytest tests/test_scheduler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6866564abecc8322843a000e407191d7